### PR TITLE
feat(galgame): add series pages and staff/character detail pages

### DIFF
--- a/apps/api/internal/app/router.go
+++ b/apps/api/internal/app/router.go
@@ -96,6 +96,11 @@ func (a *App) RegisterRoutes() {
 		middleware.RateLimit(a.RDB, "galgame-entity", 120, time.Minute),
 		a.CommonHandler.GetGalgameStaff,
 	)
+	api.Get(
+		"/galgame/series/:id",
+		middleware.RateLimit(a.RDB, "galgame-entity", 120, time.Minute),
+		a.CommonHandler.GetGalgameSeries,
+	)
 	api.Get("/galgame/mine", auth, a.PatchHandler.ListMyGalgames)
 	api.Get("/galgame/search/publish", auth, a.PatchHandler.SearchGalgameForPublish)
 	api.Post("/galgame/submit", auth, a.PatchHandler.SubmitGalgame)

--- a/apps/api/internal/common/galgame_series.go
+++ b/apps/api/internal/common/galgame_series.go
@@ -1,0 +1,110 @@
+package common
+
+import (
+	"strconv"
+
+	galgameClient "kun-galgame-patch-api/internal/galgame/client"
+	"kun-galgame-patch-api/internal/galgame/enricher"
+	patchModel "kun-galgame-patch-api/internal/patch/model"
+	"kun-galgame-patch-api/pkg/errors"
+	"kun-galgame-patch-api/pkg/response"
+	"kun-galgame-patch-api/pkg/utils"
+
+	"github.com/gofiber/fiber/v3"
+)
+
+type seriesDetailResponse struct {
+	ID          int                    `json:"id"`
+	Name        string                 `json:"name"`
+	Description string                 `json:"description,omitempty"`
+	HasNSFW     bool                   `json:"has_nsfw"`
+	Galgames    []enricher.GalgameCard `json:"galgames"`
+	Total       int64                  `json:"total"`
+}
+
+func (h *CommonHandler) GetGalgameSeries(c fiber.Ctx) error {
+	id, err := entityID(c)
+	if err != nil {
+		return response.Error(c, err)
+	}
+	page, _ := strconv.Atoi(c.Query("page", "1"))
+	limit, _ := strconv.Atoi(c.Query("limit", "24"))
+	gate := ""
+	if utils.ContentLimitForListBrowse(c) == "sfw" {
+		gate = "sfw"
+	}
+
+	rec, cerr := h.galgame.GetSeries(c.Context(), id)
+	if cerr != nil {
+		return response.Error(c, catalogEntityError(cerr, "系列"))
+	}
+
+	out := seriesDetailResponse{
+		ID:          rec.ID,
+		Name:        rec.Name,
+		Description: rec.Description,
+		HasNSFW:     rec.HasNSFW,
+		Galgames:    []enricher.GalgameCard{},
+	}
+
+	search, serr := h.galgame.SearchGalgame(c.Context(), galgameClient.SearchGalgameParams{
+		SeriesID:     id,
+		ContentLimit: gate,
+		Page:         page,
+		Limit:        limit,
+	})
+	if serr != nil {
+		return response.Error(c, errors.ErrInternal("拉取系列作品失败"))
+	}
+	out.Total = search.Total
+
+	gids := make([]int, 0, len(search.Items))
+	for i := range search.Items {
+		if search.Items[i].ID > 0 {
+			gids = append(gids, search.Items[i].ID)
+		}
+	}
+	var patches []patchModel.Patch
+	if len(gids) > 0 {
+		h.db.Where("id IN ?", gids).Find(&patches)
+	}
+	enriched := enricher.EnrichPatches(c.Context(), h.galgame, h.users, patches, "")
+	enrichedByID := make(map[int]enricher.GalgameCard, len(enriched))
+	for i := range enriched {
+		enrichedByID[enriched[i].ID] = enriched[i]
+	}
+	for i := range search.Items {
+		hit := &search.Items[i]
+		if card, ok := enrichedByID[hit.ID]; ok {
+			out.Galgames = append(out.Galgames, card)
+			continue
+		}
+		brief := hitToBrief(hit)
+		out.Galgames = append(out.Galgames, enricher.CardFromBrief(&brief))
+	}
+	return response.OK(c, out)
+}
+
+func hitToBrief(h *galgameClient.GalgameHit) galgameClient.GalgameBrief {
+	return galgameClient.GalgameBrief{
+		ID:                       h.ID,
+		CatalogWorkID:            h.CatalogWorkID,
+		VndbID:                   h.VndbID,
+		ClaimState:               h.ClaimState,
+		NameEnUs:                 h.NameEnUs,
+		NameZhCn:                 h.NameZhCn,
+		NameJaJp:                 h.NameJaJp,
+		NameZhTw:                 h.NameZhTw,
+		Banner:                   h.Banner,
+		ContentLimit:             h.ContentLimit,
+		AgeLimit:                 h.AgeLimit,
+		OriginalLanguage:         h.OriginalLanguage,
+		ReleaseDate:              h.ReleaseDate,
+		EffectiveBannerHash:      h.EffectiveBannerHash,
+		EffectiveBannerWidth:     h.EffectiveBannerWidth,
+		EffectiveBannerHeight:    h.EffectiveBannerHeight,
+		EffectiveBannerThumbhash: h.EffectiveBannerThumbhash,
+		Covers:                   h.Covers,
+		Screenshots:              h.Screenshots,
+	}
+}

--- a/apps/api/internal/galgame/client/catalog_dto.go
+++ b/apps/api/internal/galgame/client/catalog_dto.go
@@ -175,6 +175,11 @@ type catalogWorkLink struct {
 	URL    string `json:"url"`
 }
 
+type catalogWorkSeries struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+}
+
 type catalogWork struct {
 	ID            int64             `json:"id"`
 	Medium        string            `json:"medium"`
@@ -201,6 +206,7 @@ type catalogWork struct {
 	Labels      []catalogWorkLabel   `json:"labels"`
 	Engines     []catalogWorkEngine  `json:"engines"`
 	Links       []catalogWorkLink    `json:"links"`
+	Series      []catalogWorkSeries  `json:"series"`
 
 	// credits arrives only when the request asks for include=credits; the other
 	// two are always on the detail face.

--- a/apps/api/internal/galgame/client/catalog_entity_detail.go
+++ b/apps/api/internal/galgame/client/catalog_entity_detail.go
@@ -352,3 +352,35 @@ func linkHost(rawURL string) string {
 	}
 	return strings.TrimPrefix(u.Hostname(), "www.")
 }
+
+type catalogSeriesDetail struct {
+	ID          int64             `json:"id"`
+	DisplayName string            `json:"display_name"`
+	Intros      []catalogIntroRow `json:"intros"`
+	HasNSFW     bool              `json:"has_nsfw"`
+}
+
+type GalgameSeriesDetail struct {
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	HasNSFW     bool   `json:"has_nsfw"`
+}
+
+func (c *Client) GetSeries(ctx context.Context, id int) (*GalgameSeriesDetail, error) {
+	q := url.Values{}
+	applyNSFW(q)
+
+	var s catalogSeriesDetail
+	if err := c.getV1(ctx, "/catalog/series/"+strconv.Itoa(id), q, &s); err != nil {
+		return nil, err
+	}
+	out := &GalgameSeriesDetail{ID: int(s.ID), Name: s.DisplayName, HasNSFW: s.HasNSFW}
+	for _, in := range s.Intros {
+		if in.Intro != "" {
+			out.Description = in.Intro
+			break
+		}
+	}
+	return out, nil
+}

--- a/apps/api/internal/galgame/client/catalog_map.go
+++ b/apps/api/internal/galgame/client/catalog_map.go
@@ -357,6 +357,7 @@ func catalogWorkToFull(w *catalogWork) GalgameFull {
 		Characters:       catalogCharacters(w.Characters),
 		Staff:            catalogStaff(w.Credits, w.Characters),
 		Ratings:          catalogRatings(w.Ratings),
+		Series:           catalogSeries(w.Series),
 	}
 	if f.NameJaJp == "" && f.NameZhCn == "" && f.NameZhTw == "" && f.NameEnUs == "" {
 		f.NameJaJp = w.DisplayName
@@ -419,6 +420,20 @@ func catalogLabelToFullOfficial(gid int, l *catalogWorkLabel) GalgameFullOfficia
 			LogoHash: l.LogoHash,
 		},
 	}
+}
+
+func catalogSeries(rows []catalogWorkSeries) []GalgameSeries {
+	if len(rows) == 0 {
+		return nil
+	}
+	out := make([]GalgameSeries, 0, len(rows))
+	for _, s := range rows {
+		if s.ID == 0 || strings.TrimSpace(s.Name) == "" {
+			continue
+		}
+		out = append(out, GalgameSeries{ID: int(s.ID), Name: s.Name})
+	}
+	return out
 }
 
 func joinCatalogLangs(csv string) string {

--- a/apps/api/internal/galgame/client/client.go
+++ b/apps/api/internal/galgame/client/client.go
@@ -354,6 +354,11 @@ type GalgameFullOfficial struct {
 	Official   Official `json:"official"`
 }
 
+type GalgameSeries struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
 type GalgameFull struct {
 	ID               int     `json:"id"`
 	CatalogWorkID    int64   `json:"catalog_work_id,omitempty"`
@@ -378,6 +383,7 @@ type GalgameFull struct {
 	Characters []GalgameCharacter    `json:"characters"`
 	Staff      []GalgameStaffGroup   `json:"staff"`
 	Ratings    []GalgameRating       `json:"ratings"`
+	Series     []GalgameSeries       `json:"series"`
 
 	EffectiveBannerHash        string            `json:"effective_banner_hash"`
 	EffectiveBannerWidth       int               `json:"effective_banner_width,omitempty"`

--- a/apps/api/internal/galgame/enricher/enricher.go
+++ b/apps/api/internal/galgame/enricher/enricher.go
@@ -253,6 +253,7 @@ type PatchDetailCard struct {
 	Characters           []galgameClient.GalgameCharacter  `json:"characters"`
 	Staff                []galgameClient.GalgameStaffGroup `json:"staff"`
 	Ratings              []galgameClient.GalgameRating     `json:"ratings"`
+	Series               []galgameClient.GalgameSeries     `json:"series"`
 }
 
 // applyCatalogEntities copies the catalog-owned entity graph onto the detail
@@ -262,6 +263,7 @@ func applyCatalogEntities(base *PatchDetailCard, g *galgameClient.GalgameFull) {
 	base.Characters = g.Characters
 	base.Staff = g.Staff
 	base.Ratings = g.Ratings
+	base.Series = g.Series
 	for _, t := range g.Tag {
 		base.Tags = append(base.Tags, PatchDetailTag{
 			ID:           t.Tag.ID,

--- a/apps/web/app/components/galgame/Characters.vue
+++ b/apps/web/app/components/galgame/Characters.vue
@@ -53,21 +53,6 @@ const secondaryOf = (c: PatchDetailCharacter) =>
 
 const voicesOf = (c: PatchDetailCharacter) =>
   c.voices.map((v) => getPreferredLanguageText(v.name)).join(' / ')
-
-const activeCharacter = ref<PatchDetailCharacter | null>(null)
-const isCharacterOpen = ref(false)
-const openCharacter = (c: PatchDetailCharacter) => {
-  activeCharacter.value = c
-  isCharacterOpen.value = true
-}
-
-const activePerson = ref<PatchDetailPerson | null>(null)
-const isPersonOpen = ref(false)
-const openPerson = (person: PatchDetailPerson) => {
-  isCharacterOpen.value = false
-  activePerson.value = person
-  isPersonOpen.value = true
-}
 </script>
 
 <template>
@@ -98,13 +83,12 @@ const openPerson = (person: PatchDetailPerson) => {
       v-if="visibleArt.length"
       class="grid grid-cols-3 gap-3 sm:grid-cols-[repeat(auto-fill,minmax(128px,1fr))]"
     >
-      <button
+      <NuxtLink
         v-for="c in visibleArt"
         :key="c.id"
-        type="button"
+        :to="`/galgame/character/${c.id}`"
         class="group space-y-1.5 text-left"
         :aria-label="`查看角色 ${nameOf(c)}`"
-        @click="openCharacter(c)"
       >
         <div
           class="bg-default-100 group-hover:ring-primary group-focus:ring-primary relative overflow-hidden rounded-lg ring-1 ring-transparent transition-all"
@@ -153,7 +137,7 @@ const openPerson = (person: PatchDetailPerson) => {
             {{ GALGAME_CHARACTER_SPOILER_MAP[c.spoiler] }}
           </p>
         </div>
-      </button>
+      </NuxtLink>
     </div>
 
     <KunButton
@@ -179,25 +163,17 @@ const openPerson = (person: PatchDetailPerson) => {
       </p>
       <div class="flex flex-wrap items-baseline gap-x-4 gap-y-1.5">
         <span v-for="c in nameOnly" :key="c.id" class="text-sm">
-          <button
-            type="button"
-            class="text-default-800 hover:text-primary cursor-pointer"
-            @click="openCharacter(c)"
+          <NuxtLink
+            :to="`/galgame/character/${c.id}`"
+            class="text-default-800 hover:text-primary"
           >
             {{ nameOf(c) }}
-          </button>
+          </NuxtLink>
           <span v-if="c.voices.length" class="text-default-400">
             （CV {{ voicesOf(c) }}）
           </span>
         </span>
       </div>
     </div>
-
-    <GalgameCharacterModal
-      v-model="isCharacterOpen"
-      :character="activeCharacter"
-      @open-staff="openPerson"
-    />
-    <GalgameStaffModal v-model="isPersonOpen" :person="activePerson" />
   </section>
 </template>

--- a/apps/web/app/components/galgame/Gallery.vue
+++ b/apps/web/app/components/galgame/Gallery.vue
@@ -36,6 +36,17 @@ const sorted = computed(() =>
 
 const hiddenCount = computed(() => allShots.value.length - sorted.value.length)
 
+const PREVIEW = 12
+const isExpanded = ref(false)
+const visible = computed(() =>
+  isExpanded.value ? sorted.value : sorted.value.slice(0, PREVIEW)
+)
+const folded = computed(() => sorted.value.length - visible.value.length)
+const foldIndex = computed(() => (folded.value > 0 ? visible.value.length - 1 : -1))
+const expand = () => {
+  isExpanded.value = true
+}
+
 const hasRated = computed(() =>
   allShots.value.some((s) => s.sexual >= 1 || s.violence >= 1)
 )
@@ -89,34 +100,50 @@ const imgSrc = (s: GalgameScreenshotRow) => imageServiceUrl(s.image_hash)
         class="grid grid-cols-1 items-start gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
       >
         <KunLightboxGalleryItem
-          v-for="s in sorted"
+          v-for="(s, i) in visible"
           :key="s.image_hash"
           :src="imgSrc(s)"
           :alt="s.caption || s.image_hash.slice(0, 8)"
-          as="figure"
-          class="border-default/20 block overflow-hidden rounded-lg border"
+          :wrap="false"
+          v-slot="{ open }"
         >
-          <div class="relative">
-            <KunImage
-              :src="imgSrc(s)"
-              :alt="s.caption || s.image_hash.slice(0, 8)"
-              loading="lazy"
-              :aspect-ratio="imageAspectRatio(s.width, s.height)"
-              :thumbhash="s.thumbhash"
-              class-name="bg-default-100"
-            />
-            <div
-              v-if="s.sexual >= 1 || s.violence >= 1"
-              class="pointer-events-none absolute inset-0"
-              :style="ratingRing(s)"
-            />
-          </div>
-          <figcaption
-            v-if="s.caption"
-            class="text-default-500 px-2 py-1 text-xs"
+          <button
+            type="button"
+            class="group relative block w-full overflow-hidden rounded-lg text-left"
+            :aria-label="
+              i === foldIndex ? '显示全部截图' : (s.caption || '查看截图')
+            "
+            @click="i === foldIndex ? expand() : open()"
           >
-            {{ s.caption }}
-          </figcaption>
+            <div class="relative">
+              <KunImage
+                :src="imgSrc(s)"
+                :alt="s.caption || s.image_hash.slice(0, 8)"
+                loading="lazy"
+                :aspect-ratio="imageAspectRatio(s.width, s.height)"
+                :thumbhash="s.thumbhash"
+                class-name="bg-default-100"
+              />
+              <div
+                v-if="s.sexual >= 1 || s.violence >= 1"
+                class="pointer-events-none absolute inset-0"
+                :style="ratingRing(s)"
+              />
+            </div>
+            <figcaption
+              v-if="s.caption"
+              class="text-default-500 px-2 py-1 text-xs"
+            >
+              {{ s.caption }}
+            </figcaption>
+            <div
+              v-if="i === foldIndex"
+              class="absolute inset-0 flex flex-col items-center justify-center gap-1 rounded-lg bg-black/60 text-white"
+            >
+              <span class="text-lg font-medium">+{{ folded }}</span>
+              <span class="text-xs">显示全部</span>
+            </div>
+          </button>
         </KunLightboxGalleryItem>
       </div>
     </KunLightboxGallery>

--- a/apps/web/app/components/galgame/Series.vue
+++ b/apps/web/app/components/galgame/Series.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+const props = defineProps<{
+  series: PatchDetailSeries[]
+}>()
+</script>
+
+<template>
+  <section v-if="series.length" class="space-y-4">
+    <KunHeader
+      name="Galgame 系列"
+      description="该 Galgame 所属的系列作品合集"
+      scale="h2"
+    />
+
+    <div class="flex flex-wrap gap-2">
+      <NuxtLink
+        v-for="s in series"
+        :key="s.id"
+        :to="`/galgame/series/${s.id}`"
+      >
+        <KunChip color="primary" variant="flat" size="sm">
+          {{ s.name }}
+        </KunChip>
+      </NuxtLink>
+    </div>
+  </section>
+</template>

--- a/apps/web/app/components/galgame/Staff.vue
+++ b/apps/web/app/components/galgame/Staff.vue
@@ -15,13 +15,6 @@ const visible = computed(() =>
 
 const playedText = (characters?: KunLanguage[]) =>
   (characters ?? []).map((c) => getPreferredLanguageText(c)).join(' / ')
-
-const activePerson = ref<PatchDetailPerson | null>(null)
-const isPersonOpen = ref(false)
-const openPerson = (person: PatchDetailPerson) => {
-  activePerson.value = person
-  isPersonOpen.value = true
-}
 </script>
 
 <template>
@@ -43,13 +36,12 @@ const openPerson = (person: PatchDetailPerson) => {
         </dt>
         <dd class="flex flex-wrap items-baseline gap-x-4 gap-y-1.5">
           <span v-for="person in group.people" :key="person.id" class="text-sm">
-            <button
-              type="button"
-              class="text-default-800 hover:text-primary cursor-pointer"
-              @click="openPerson(person)"
+            <NuxtLink
+              :to="`/galgame/staff/${person.id}`"
+              class="text-default-800 hover:text-primary"
             >
               {{ getPreferredLanguageText(person.name) }}
-            </button>
+            </NuxtLink>
             <span v-if="person.characters?.length" class="text-default-400">
               （{{ playedText(person.characters) }}）
             </span>
@@ -74,7 +66,5 @@ const openPerson = (person: PatchDetailPerson) => {
           : `展开其余 ${staff.length - COLLAPSED} 项职位`
       }}
     </KunButton>
-
-    <GalgameStaffModal v-model="isPersonOpen" :person="activePerson" />
   </section>
 </template>

--- a/apps/web/app/pages/galgame/character/[id].vue
+++ b/apps/web/app/pages/galgame/character/[id].vue
@@ -1,0 +1,215 @@
+<script setup lang="ts">
+import { imageServiceUrl } from '~/shared/utils/resolveBannerUrl'
+
+const route = useRoute()
+const router = useRouter()
+const api = useApi()
+
+const goBack = () => router.back()
+
+const characterId = computed(() => Number((route.params as { id: string }).id))
+
+const { data } = await useAsyncData<PatchCharacterDetail | null>(
+  () => `galgame-character-${characterId.value}`,
+  async () => {
+    const res = await api.get<PatchCharacterDetail>(
+      `/galgame/character/${characterId.value}`
+    )
+    return res.code === 0 ? res.data : null
+  }
+)
+
+const character = computed(() => data.value)
+
+const name = computed(() => getPreferredLanguageText(character.value?.name))
+const secondaryName = computed(() =>
+  getSecondaryLanguageText(character.value?.name, name.value)
+)
+
+const figureSrc = computed(() =>
+  imageServiceUrl(character.value?.figure_hash ?? '')
+)
+const imageSrc = computed(() =>
+  imageServiceUrl(character.value?.image_hash ?? '')
+)
+
+const intro = computed(() => pickPreferredLanguageRow(character.value?.intros))
+
+const aliases = computed(() =>
+  (character.value?.aliases ?? []).filter(
+    (alias) => alias !== name.value && alias !== secondaryName.value
+  )
+)
+
+const isTraitSpoilerRevealed = ref(false)
+const traits = computed(() =>
+  (character.value?.traits ?? []).filter(
+    (t) => isTraitSpoilerRevealed.value || t.spoiler === 0
+  )
+)
+const hiddenTraitCount = computed(
+  () => (character.value?.traits ?? []).filter((t) => t.spoiler > 0).length
+)
+const traitGroups = computed(() => {
+  const groups: { name: string; traits: PatchCharacterTrait[] }[] = []
+  for (const trait of traits.value) {
+    const group = trait.group || '其他'
+    const last = groups.at(-1)
+    if (last?.name === group) {
+      last.traits.push(trait)
+    } else {
+      groups.push({ name: group, traits: [trait] })
+    }
+  }
+  return groups
+})
+
+useHead(() => ({
+  title: name.value ? `${name.value} 的角色资料` : '角色'
+}))
+</script>
+
+<template>
+  <div
+    v-if="character"
+    class="mx-auto w-full max-w-7xl space-y-6 px-3 py-4"
+  >
+    <button
+      type="button"
+      class="text-default-500 hover:text-default-700 flex items-center gap-1 text-sm"
+      @click="goBack"
+    >
+      <KunIcon name="lucide:arrow-left" class="size-4" />
+      返回
+    </button>
+
+    <div class="bg-content1 shadow-kun-sm rounded-3xl p-6 sm:p-8">
+      <div class="flex flex-col gap-5 sm:flex-row">
+        <KunLightboxGallery v-if="figureSrc || imageSrc">
+          <div class="flex shrink-0 items-start gap-3 sm:flex-col">
+            <KunLightboxGalleryItem
+              v-if="figureSrc"
+              v-slot="{ open }"
+              :src="figureSrc"
+              :alt="name"
+              :wrap="false"
+            >
+              <button
+                type="button"
+                class="bg-default-100 w-fit cursor-zoom-in overflow-hidden rounded-xl"
+                :aria-label="`查看 ${name} 的立绘`"
+                @click="open"
+              >
+                <KunImage
+                  :src="figureSrc"
+                  :alt="name"
+                  loading="eager"
+                  object-fit="contain"
+                  class-name="w-32 sm:w-44"
+                />
+              </button>
+            </KunLightboxGalleryItem>
+
+            <KunLightboxGalleryItem
+              v-if="imageSrc"
+              v-slot="{ open }"
+              :src="imageSrc"
+              :alt="name"
+              :wrap="false"
+            >
+              <button
+                type="button"
+                class="bg-default-100 w-fit cursor-zoom-in overflow-hidden rounded-xl"
+                :aria-label="`查看 ${name} 的头像`"
+                @click="open"
+              >
+                <KunImage
+                  :src="imageSrc"
+                  :alt="name"
+                  loading="eager"
+                  aspect-ratio="3/4"
+                  object-fit="cover"
+                  :class-name="figureSrc ? 'w-20 sm:w-24' : 'w-32 sm:w-44'"
+                />
+              </button>
+            </KunLightboxGalleryItem>
+          </div>
+        </KunLightboxGallery>
+
+        <div class="min-w-0 grow space-y-3">
+          <div class="space-y-1">
+            <h1 class="text-2xl font-bold break-words sm:text-3xl">
+              {{ name }}
+            </h1>
+            <p v-if="secondaryName" class="text-default-400 text-sm">
+              {{ secondaryName }}
+            </p>
+            <p v-if="aliases.length" class="text-default-500 text-sm">
+              别名 {{ aliases.join(' / ') }}
+            </p>
+          </div>
+
+          <div v-if="intro" class="space-y-1">
+            <p class="text-default-600 text-sm whitespace-pre-line">
+              {{ intro.intro }}
+            </p>
+            <p class="text-default-400 text-xs">
+              资料来自 {{ intro.source || '鲲 Galgame 目录'
+              }}<template v-if="intro.machine">, 由机器翻译</template>
+            </p>
+          </div>
+
+          <div v-if="traitGroups.length" class="space-y-2">
+            <div
+              v-for="group in traitGroups"
+              :key="group.name"
+              class="space-y-1"
+            >
+              <p class="text-default-400 text-xs">{{ group.name }}</p>
+              <div class="flex flex-wrap gap-1.5">
+                <KunChip
+                  v-for="trait in group.traits"
+                  :key="trait.id"
+                  size="xs"
+                  :color="trait.spoiler > 0 ? 'warning' : 'default'"
+                >
+                  {{ trait.name }}<template v-if="trait.lie">（伪）</template>
+                </KunChip>
+              </div>
+            </div>
+          </div>
+
+          <KunButton
+            v-if="hiddenTraitCount && !isTraitSpoilerRevealed"
+            variant="flat"
+            color="warning"
+            size="sm"
+            @click="isTraitSpoilerRevealed = true"
+          >
+            <KunIcon name="lucide:eye" />
+            显示 {{ hiddenTraitCount }} 条剧透特征
+          </KunButton>
+
+          <div
+            v-if="character.links.length"
+            class="flex flex-wrap items-center gap-x-4 gap-y-2"
+          >
+            <a
+              v-for="link in character.links"
+              :key="link.url"
+              :href="link.url"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-default-500 hover:text-primary text-sm"
+            >
+              {{ link.name }}
+              <KunIcon name="lucide:external-link" class="inline size-3" />
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <KunNull v-else description="未找到该角色" />
+</template>

--- a/apps/web/app/pages/galgame/series/[id].vue
+++ b/apps/web/app/pages/galgame/series/[id].vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+const route = useRoute()
+const api = useApi()
+
+const seriesId = computed(() => Number((route.params as { id: string }).id))
+
+const PAGE_SIZE = 24
+
+const { data } = await useAsyncData<SeriesDetail | null>(
+  () => `galgame-series-${seriesId.value}`,
+  async () => {
+    const res = await api.get<SeriesDetail>(
+      `/galgame/series/${seriesId.value}?page=1&limit=${PAGE_SIZE}`
+    )
+    return res.code === 0 ? res.data : null
+  }
+)
+
+const series = computed(() => data.value)
+
+const galgames = ref<GalgameCard[]>([])
+const page = ref(1)
+const loadingMore = ref(false)
+
+watch(
+  () => data.value,
+  (d) => {
+    if (d) {
+      galgames.value = [...d.galgames]
+      page.value = 1
+    }
+  },
+  { immediate: true }
+)
+
+const hasMore = computed(
+  () => !!series.value && galgames.value.length < series.value.total
+)
+
+const loadMore = async () => {
+  if (!hasMore.value || loadingMore.value) {
+    return
+  }
+  loadingMore.value = true
+  const next = page.value + 1
+  const res = await api.get<SeriesDetail>(
+    `/galgame/series/${seriesId.value}?page=${next}&limit=${PAGE_SIZE}`
+  )
+  loadingMore.value = false
+  if (res.code !== 0 || !res.data) {
+    return
+  }
+  galgames.value.push(...res.data.galgames)
+  page.value = next
+}
+
+useHead(() => ({
+  title: series.value ? `${series.value.name} 系列的 Galgame` : 'Galgame 系列'
+}))
+</script>
+
+<template>
+  <div
+    v-if="series"
+    class="mx-auto w-full max-w-7xl space-y-6 px-3 py-4"
+  >
+    <div class="bg-content1 shadow-kun-sm rounded-3xl p-6 sm:p-8">
+      <div class="space-y-2">
+        <h1 class="text-2xl font-bold break-words sm:text-3xl">
+          {{ series.name }} 系列的 Galgame
+        </h1>
+        <p v-if="series.description" class="text-default-600">
+          {{ series.description }}
+        </p>
+        <p class="text-default-500 text-sm">
+          本页展示该系列的全部 Galgame，共 {{ series.total }} 部。默认仅显示
+          SFW 的 Galgame，查看 NSFW Galgame 请在顶部设置面板打开 NSFW 开关。
+        </p>
+      </div>
+    </div>
+
+    <div
+      v-if="galgames.length"
+      class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+    >
+      <GalgameCard v-for="g in galgames" :key="g.id" :patch="g" />
+    </div>
+    <KunNull v-else description="该系列下暂无 Galgame" />
+
+    <div v-if="hasMore" class="flex justify-center">
+      <KunButton
+        variant="flat"
+        color="primary"
+        :is-loading="loadingMore"
+        @click="loadMore"
+      >
+        加载更多作品
+      </KunButton>
+    </div>
+  </div>
+
+  <KunNull v-else description="未找到该系列" />
+</template>

--- a/apps/web/app/pages/galgame/staff/[id].vue
+++ b/apps/web/app/pages/galgame/staff/[id].vue
@@ -1,0 +1,165 @@
+<script setup lang="ts">
+import { GALGAME_STAFF_GENDER_MAP } from '~/constants/galgameEntity'
+import { imageServiceUrl } from '~/shared/utils/resolveBannerUrl'
+
+const route = useRoute()
+const api = useApi()
+
+const staffId = computed(() => Number((route.params as { id: string }).id))
+
+const { data } = await useAsyncData<PatchStaffDetail | null>(
+  () => `galgame-staff-${staffId.value}`,
+  async () => {
+    const res = await api.get<PatchStaffDetail>(`/galgame/staff/${staffId.value}`)
+    return res.code === 0 ? res.data : null
+  }
+)
+
+const staff = computed(() => data.value)
+
+const name = computed(() => getPreferredLanguageText(staff.value?.name))
+const secondaryName = computed(() =>
+  getSecondaryLanguageText(staff.value?.name, name.value)
+)
+
+const photoSrc = computed(() => imageServiceUrl(staff.value?.photo_hash ?? ''))
+
+const intro = computed(() => pickPreferredLanguageRow(staff.value?.intros))
+
+const aliases = computed(() =>
+  (staff.value?.aliases ?? []).filter(
+    (alias) => alias !== name.value && alias !== secondaryName.value
+  )
+)
+
+const birthday = computed(() => {
+  const d = staff.value
+  if (!d) return ''
+  const md = d.birth_m && d.birth_d ? `${d.birth_m} 月 ${d.birth_d} 日` : ''
+  const year = d.birth_y ? `${d.birth_y} 年` : ''
+  return [year, md].filter(Boolean).join(' ')
+})
+
+const facts = computed(() => {
+  const rows: string[] = []
+  const gender = staff.value?.gender
+  if (gender && GALGAME_STAFF_GENDER_MAP[gender]) {
+    rows.push(GALGAME_STAFF_GENDER_MAP[gender])
+  }
+  if (birthday.value) rows.push(`生日 ${birthday.value}`)
+  return rows
+})
+
+const roleText = (credit: PatchStaffCredit) =>
+  credit.roles
+    .map((r) => (r.character ? `${r.role_name}（${r.character}）` : r.role_name))
+    .join(' · ')
+
+useHead(() => ({
+  title: name.value ? `${name.value} 参与制作的 Galgame` : '制作人员'
+}))
+</script>
+
+<template>
+  <div
+    v-if="staff"
+    class="mx-auto w-full max-w-7xl space-y-6 px-3 py-4"
+  >
+    <div class="bg-content1 shadow-kun-sm rounded-3xl p-6 sm:p-8">
+      <div class="flex items-start gap-4">
+        <KunImage
+          v-if="photoSrc"
+          :src="photoSrc"
+          :alt="name"
+          loading="eager"
+          aspect-ratio="1/1"
+          object-fit="cover"
+          class-name="w-24 shrink-0 overflow-hidden rounded-xl sm:w-32"
+        />
+
+        <div class="min-w-0 grow space-y-2">
+          <h1 class="text-2xl font-bold break-words sm:text-3xl">
+            {{ name }}
+          </h1>
+          <p v-if="secondaryName" class="text-default-400 text-sm">
+            {{ secondaryName }}
+          </p>
+          <p v-if="facts.length" class="text-default-500 text-sm">
+            {{ facts.join(' · ') }}
+          </p>
+          <p v-if="aliases.length" class="text-default-500 text-sm">
+            别名 {{ aliases.join(' / ') }}
+          </p>
+        </div>
+      </div>
+
+      <div v-if="intro" class="mt-4 space-y-1">
+        <p class="text-default-600 text-sm whitespace-pre-line">
+          {{ intro.intro }}
+        </p>
+        <p class="text-default-400 text-xs">
+          资料来自 {{ intro.source || '鲲 Galgame 目录'
+          }}<template v-if="intro.machine">, 由机器翻译</template>
+        </p>
+      </div>
+
+      <div v-if="staff.siblings.length" class="mt-4 space-y-1.5">
+        <p class="text-default-400 text-xs">其他名义</p>
+        <div class="flex flex-wrap items-baseline gap-x-4 gap-y-1.5">
+          <NuxtLink
+            v-for="sibling in staff.siblings"
+            :key="sibling.id"
+            :to="`/galgame/staff/${sibling.id}`"
+            class="text-default-800 hover:text-primary text-sm"
+          >
+            {{ getPreferredLanguageText(sibling.name) }}
+          </NuxtLink>
+        </div>
+      </div>
+
+      <div v-if="staff.links.length" class="mt-4 flex flex-wrap gap-3">
+        <a
+          v-for="link in staff.links"
+          :key="link.url"
+          :href="link.url"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-default-500 hover:text-primary text-sm"
+        >
+          {{ link.name }}
+          <KunIcon name="lucide:external-link" class="inline size-3" />
+        </a>
+      </div>
+    </div>
+
+    <section v-if="staff.credits.length" class="space-y-4">
+      <KunHeader
+        name="参与作品"
+        :description="`共 ${staff.credits.length} 部`"
+        scale="h2"
+      />
+
+      <ul class="space-y-2">
+        <li
+          v-for="(credit, index) in staff.credits"
+          :key="`${credit.galgame_id}-${index}`"
+          class="bg-content1 shadow-kun-sm flex flex-wrap items-baseline gap-x-3 gap-y-1 rounded-2xl px-4 py-3"
+        >
+          <NuxtLink
+            v-if="credit.galgame_id"
+            :to="`/patch/${credit.galgame_id}`"
+            class="text-default-800 hover:text-primary"
+          >
+            {{ getPreferredLanguageText(credit.name) }}
+          </NuxtLink>
+          <span v-else class="text-default-600">
+            {{ getPreferredLanguageText(credit.name) }}
+          </span>
+          <span class="text-default-400 text-xs">{{ roleText(credit) }}</span>
+        </li>
+      </ul>
+    </section>
+  </div>
+
+  <KunNull v-else description="未找到该制作人员" />
+</template>

--- a/apps/web/app/pages/patch/[id]/introduction.vue
+++ b/apps/web/app/pages/patch/[id]/introduction.vue
@@ -300,6 +300,8 @@ const kungalOrigin = kunMoyuMoe.domain.kungal
 
     <GalgameStaff :staff="staffGroups" />
 
+    <GalgameSeries :series="detail.series ?? []" />
+
     <section v-if="detail.galgame?.screenshots?.length">
       <GalgameGallery :screenshots="detail.galgame.screenshots" />
     </section>

--- a/apps/web/app/shared/types/patch.d.ts
+++ b/apps/web/app/shared/types/patch.d.ts
@@ -269,6 +269,11 @@ interface PatchDetailRating {
   distribution?: PatchDetailRatingBucket[]
 }
 
+interface PatchDetailSeries {
+  id: number
+  name: string
+}
+
 interface PatchDetail extends GalgameCard {
   introduction_markdown: KunLanguage
   introduction_html: KunLanguage
@@ -278,5 +283,6 @@ interface PatchDetail extends GalgameCard {
   characters: PatchDetailCharacter[]
   staff: PatchDetailStaffGroup[]
   ratings: PatchDetailRating[]
+  series: PatchDetailSeries[]
   wiki_engine_ids: number[]
 }

--- a/apps/web/app/shared/types/series.d.ts
+++ b/apps/web/app/shared/types/series.d.ts
@@ -1,0 +1,8 @@
+interface SeriesDetail {
+  id: number
+  name: string
+  description?: string
+  has_nsfw: boolean
+  galgames: GalgameCard[]
+  total: number
+}


### PR DESCRIPTION
## 问题 / Problem

1. 补丁站没有「系列」详情页，简介页也没有系列入口。
   The patch site has no series detail page, and the intro page has no series entry.
2. 角色 / 职员点击只能弹 modal（或跳转到 kungal.com），没有站内独立详情页。
   Character / staff clicks only open a modal (or jump to kungal.com); there is no dedicated in-site detail page.
3. 画廊截图超过 12 张时全部平铺，页面过长。
   The gallery lays out every screenshot once there are more than 12, making the page unwieldy.

## 原因 / Cause

1. 后端 catalog client 缺少 series 实体读取能力（已有 tag / official / name / character，唯独没有 series）。
   The backend catalog client had no series entity reader (it already covered tag / official / name / character, but not series).
2. 角色 / 职员详情只做了 modal，没有独立页面路由；简介页实体点击绑定的是 modal 而不是页面导航。
   Character / staff detail was only implemented as a modal, not as a dedicated route; the intro page bound entity clicks to the modal instead of navigation.
3. 画廊组件没有任何折叠逻辑。
   The gallery component had no collapse logic.

## 解决方式 / Solution

1. 后端新增 `GetSeries` 与 `GET /galgame/series/:id` 接口，简介页通过 `PatchDetail.series` 展示「Galgame 系列」chip。
   Add `GetSeries` and `GET /galgame/series/:id` on the backend, and surface series chips via `PatchDetail.series`.
2. 新增 `/galgame/staff/[id]` 与 `/galgame/character/[id]` 独立详情页，并把简介页的职员 / 角色入口改为站内导航（复用已有的 `/galgame/staff/:id`、`/galgame/character/:id` 接口）。
   Add `/galgame/staff/[id]` and `/galgame/character/[id]` pages, and point the intro page's staff / character names at them (reusing the existing `/galgame/staff/:id` and `/galgame/character/:id` endpoints).
3. 画廊超过 12 张时折叠，最后一张显示「+N 显示全部」，点击后展开全部。
   Fold the gallery past 12 images behind a "+N 显示全部" card that expands on click.

## 变更 / Changes

- 后端：`apps/api/internal/common/galgame_series.go`、`catalog_entity_detail.go`（`GetSeries`）、`catalog_dto.go` / `catalog_map.go` / `client.go`（series 映射）、`enricher.go`（`series` 字段）、`router.go`（路由）
- 前端：`pages/galgame/{series,staff,character}/[id].vue`、`components/galgame/Series.vue`、`components/galgame/Gallery.vue`（折叠）、`Staff.vue` / `Characters.vue`（站内导航）、`shared/types/{series,patch}.d.ts`
