### PR TITLE
feat(web): remove the NSFW-only content display mode

### DIFF
--- a/apps/web/app/components/kun/top-bar/MobileMenu.vue
+++ b/apps/web/app/components/kun/top-bar/MobileMenu.vue
@@ -31,8 +31,7 @@ const setTheme = (key: 'light' | 'dark' | 'system') => {
 const settingStore = useSettingStore()
 const nsfwOptions = [
   { key: 'sfw', icon: 'lucide:shield-check' },
-  { key: 'all', icon: 'lucide:circle-slash' },
-  { key: 'nsfw', icon: 'lucide:ban' }
+  { key: 'all', icon: 'lucide:circle-slash' }
 ] as const satisfies ReadonlyArray<{ key: KunNsfwPreference; icon: string }>
 const setNsfw = (key: KunNsfwPreference) => {
   settingStore.setNsfwPreference(key)
@@ -326,7 +325,7 @@ onUnmounted(() => {
               内容显示
             </p>
             <div
-              class="border-default/20 bg-default-50/40 grid grid-cols-3 gap-1 rounded-xl border p-1"
+              class="border-default/20 bg-default-50/40 grid grid-cols-2 gap-1 rounded-xl border p-1"
             >
               <KunButton
                 v-for="opt in nsfwOptions"

--- a/apps/web/app/components/kun/top-bar/NSFWSwitcher.vue
+++ b/apps/web/app/components/kun/top-bar/NSFWSwitcher.vue
@@ -9,7 +9,6 @@ const settingStore = useSettingStore()
 
 const options = [
   { key: 'sfw', icon: 'lucide:shield-check' },
-  { key: 'nsfw', icon: 'lucide:ban' },
   { key: 'all', icon: 'lucide:circle-slash' }
 ] as const satisfies ReadonlyArray<{ key: KunNsfwPreference; icon: string }>
 

--- a/apps/web/app/composables/useApi.ts
+++ b/apps/web/app/composables/useApi.ts
@@ -56,8 +56,8 @@ export const useApi = () => {
   // unknown params, and the moyu backend only reads it where applicable.
   //
   // Resolution priority (first match wins):
-  //   1. Explicit cookie preference != 'sfw' — user picked nsfw / all in
-  //      the top-bar switcher, honour it verbatim. This is the ONLY way
+  //   1. Explicit cookie preference != 'sfw' — user picked 'all' in the
+  //      top-bar switcher, honour it verbatim. This is the ONLY way
   //      listing pages (home / galgame / resource / ranking / user-tabs /
   //      taxonomy) ever return NSFW content; just being logged-in does
   //      NOT flip lists to all — per product rule, "页面上的各种游戏列表

--- a/apps/web/app/constants/top-bar.ts
+++ b/apps/web/app/constants/top-bar.ts
@@ -38,14 +38,12 @@ export const kunMobileAdminItem: KunNavItem[] = [
 
 export const KUN_CONTENT_LIMIT_MAP: Record<string, string> = {
   sfw: '仅显示 SFW (内容安全) 的内容',
-  nsfw: '仅显示 NSFW (可能含有 R18) 的内容',
   all: '同时显示 SFW 和 NSFW 的内容'
 }
 
 export const KUN_CONTENT_LIMIT_LABEL: Record<string, string> = {
   '': '全年龄',
   sfw: '全年龄',
-  nsfw: '涩涩模式',
   all: 'R18模式'
 }
 

--- a/apps/web/app/pages/settings/system.vue
+++ b/apps/web/app/pages/settings/system.vue
@@ -19,8 +19,7 @@ const setTheme = (key: 'light' | 'dark' | 'system') => {
 
 const nsfwOptions = [
   { key: 'sfw', icon: 'lucide:shield-check' },
-  { key: 'all', icon: 'lucide:circle-slash' },
-  { key: 'nsfw', icon: 'lucide:ban' }
+  { key: 'all', icon: 'lucide:circle-slash' }
 ] as const satisfies ReadonlyArray<{ key: KunNsfwPreference; icon: string }>
 const setNsfw = (key: KunNsfwPreference) => {
   settingStore.setNsfwPreference(key)
@@ -103,7 +102,7 @@ onMounted(() => {
             控制是否显示 R18 等成人内容（切换后会刷新页面以立即生效）
           </p>
           <div
-            class="border-default/20 bg-default-50/40 grid grid-cols-3 gap-1 rounded-xl border p-1"
+            class="border-default/20 bg-default-50/40 grid grid-cols-2 gap-1 rounded-xl border p-1"
           >
             <KunButton
               v-for="opt in nsfwOptions"

--- a/apps/web/app/stores/settingStore.ts
+++ b/apps/web/app/stores/settingStore.ts
@@ -2,14 +2,10 @@ import { defineStore } from 'pinia'
 
 // NSFW preference. Maps 1:1 to the wiki content_limit query parameter per
 // docs/galgame_wiki/00-handbook §16 — useApi forwards it verbatim:
-//   'sfw'  — only SFW games (the safe-by-default; also what we send on
-//             SSR fallback / signed-out / cookie missing)
-//   'nsfw' — only NSFW games (curiosity mode)
-//   'all'  — both
-//
-// Stored as a plain string (not boolean) so the front-end NSFW toggle UI
-// can offer all three modes if needed without rewriting the protocol.
-export type KunNsfwPreference = 'sfw' | 'nsfw' | 'all'
+//   'sfw' — only SFW games (the safe-by-default; also what we send on
+//            SSR fallback / signed-out / cookie missing)
+//   'all' — both SFW and NSFW
+export type KunNsfwPreference = 'sfw' | 'all'
 
 export interface KunSettingData {
   kunNsfwEnable: KunNsfwPreference


### PR DESCRIPTION
## Bug / 问题

The top-bar content filter offered three modes: SFW only, NSFW only, and "show all". The "仅显示 NSFW 内容" (NSFW-only) mode is no longer wanted — a site filter that surfaces *only* R18/NSFW content has no legitimate browsing use and should be removed.

顶栏内容筛选提供了三种模式：仅 SFW、仅 NSFW、"显示全部"。其中"仅显示 NSFW 内容"模式已不再需要——只展示 R18 内容的筛选模式没有正当的浏览用途，应被移除。

## Root cause / 原因

`KunNsfwPreference` was modeled as a three-way union `'sfw' | 'nsfw' | 'all'`, and the `nsfw` option was wired into the top-bar switcher, the mobile menu, and the settings page through `KUN_CONTENT_LIMIT_MAP` / `KUN_CONTENT_LIMIT_LABEL`.

`KunNsfwPreference` 被建模为三态联合类型 `'sfw' | 'nsfw' | 'all'`，且 `nsfw` 选项通过 `KUN_CONTENT_LIMIT_MAP` / `KUN_CONTENT_LIMIT_LABEL` 接入顶栏切换器、移动端菜单和设置页。

## Solution / 解决方式

- Narrow `KunNsfwPreference` to `'sfw' | 'all'`.
- Drop the `nsfw` entries from `KUN_CONTENT_LIMIT_MAP` and `KUN_CONTENT_LIMIT_LABEL`.
- Remove the `nsfw` option from the top-bar switcher, the mobile menu, and the settings page, and collapse the option grids from 3 columns to 2.

- 将 `KunNsfwPreference` 收窄为 `'sfw' | 'all'`。
- 删除 `KUN_CONTENT_LIMIT_MAP` 与 `KUN_CONTENT_LIMIT_LABEL` 中的 `nsfw` 项。
- 移除顶栏切换器、移动端菜单、设置页中的 `nsfw` 选项，并将选项网格由 3 列改为 2 列。
