### PR TITLE
perf(catalog): cache the S2S read faces in redis (the forum's 09-02 fix, one client down)

### DIFF
--- a/apps/api/internal/app/app.go
+++ b/apps/api/internal/app/app.go
@@ -89,7 +89,7 @@ func New(cfg *config.Config) *App {
 
 	db := database.NewPostgres(cfg.Database, cfg.Server.Mode)
 	rdb := cache.NewRedis(cfg.Redis)
-	galgame := galgameClient.NewWithKey(cfg.NextMoeAPI.BaseURL, cfg.NextMoeAPI.APIKey)
+	galgame := galgameClient.NewWithKey(cfg.NextMoeAPI.BaseURL, cfg.NextMoeAPI.APIKey).WithRedis(rdb)
 
 	usrCli := userclient.New(userclient.Config{
 		BaseURL:      cfg.OAuth.ServerURL,

--- a/apps/api/internal/galgame/client/client.go
+++ b/apps/api/internal/galgame/client/client.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"kun-galgame-patch-api/pkg/catalogv2"
+
+	"github.com/redis/go-redis/v9"
 )
 
 const galgameCodeNotFound = 404
@@ -76,6 +78,14 @@ func NewWithKey(baseURL, apiKey string) *Client {
 }
 
 func (c *Client) V2() *catalogv2.Client { return c.v2 }
+
+// WithRedis hands the catalog client the shared read cache. Optional on
+// purpose: a client built without it makes every read a request, which is what
+// the tests want.
+func (c *Client) WithRedis(rdb *redis.Client) *Client {
+	c.v2.WithRedis(rdb)
+	return c
+}
 
 type Paginated[T any] struct {
 	Items []T   `json:"items"`

--- a/apps/api/pkg/catalogv2/cache.go
+++ b/apps/api/pkg/catalogv2/cache.go
@@ -1,0 +1,100 @@
+package catalogv2
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	readCacheKeyPrefix = "nmcache:moyu:v2:"
+	readCacheMaxBody   = 512 << 10
+	readCacheDetailTTL = 15 * time.Second
+	readCacheListTTL   = 60 * time.Second
+)
+
+// The public read faces, and only those. An allowlist rather than a list of
+// exclusions, because the lanes that must never be cached are exactly the ones
+// a later reader would forget to exclude: /v2/catalog/changes and
+// /v2/catalog/claim-events drive incremental cursor loops where a stale page
+// silently skips a window, and /v2/catalog/proposals is what an editor reloads
+// to see the edit they just submitted.
+//
+// Safe only because the S2S GET path sends no request header that varies by
+// caller — the URL alone determines the response, and every face spells the
+// content limit into the query (nsfw=true / nsfw=false, always explicit), so
+// two readers with different limits can never share a key.
+var readCachePaths = []string{
+	"/v2/catalog/works",
+	"/v2/catalog/calendar",
+	"/v2/catalog/search",
+	"/v2/catalog/companies",
+	"/v2/catalog/credit-names",
+	"/v2/catalog/characters",
+	"/v2/catalog/series",
+	"/v2/catalog/tags",
+	"/v2/catalog/schemas",
+}
+
+// WithRedis turns on the shared read cache. A client without it behaves exactly
+// as before, which is what the tests and the one-off tools get.
+func (c *Client) WithRedis(rdb *redis.Client) *Client {
+	c.rdb = rdb
+	return c
+}
+
+func readCacheable(path string) bool {
+	route, _, _ := strings.Cut(path, "?")
+	for _, p := range readCachePaths {
+		if route == p || strings.HasPrefix(route, p+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func readCacheTTL(path string) time.Duration {
+	route, _, _ := strings.Cut(path, "?")
+	for _, seg := range strings.Split(route, "/") {
+		if isNumericSegment(seg) {
+			return readCacheDetailTTL
+		}
+	}
+	return readCacheListTTL
+}
+
+func isNumericSegment(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// A nil receiver is a supported state, not a bug: Configured() is written
+// `c != nil && ...` precisely so an unconfigured deployment can carry a nil
+// client and have every read come back ErrNotConfigured. Dereferencing c here
+// turned that into a panic inside the fiber handler.
+func (c *Client) cacheGet(ctx context.Context, path string) ([]byte, bool) {
+	if c == nil || c.rdb == nil || !readCacheable(path) {
+		return nil, false
+	}
+	body, err := c.rdb.Get(ctx, readCacheKeyPrefix+path).Bytes()
+	if err != nil {
+		return nil, false
+	}
+	return body, true
+}
+
+func (c *Client) cacheSet(ctx context.Context, path string, body []byte) {
+	if c == nil || c.rdb == nil || !readCacheable(path) || len(body) == 0 || len(body) > readCacheMaxBody {
+		return
+	}
+	c.rdb.Set(ctx, readCacheKeyPrefix+path, body, readCacheTTL(path))
+}

--- a/apps/api/pkg/catalogv2/cache_test.go
+++ b/apps/api/pkg/catalogv2/cache_test.go
@@ -1,0 +1,146 @@
+package catalogv2_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"kun-galgame-patch-api/pkg/catalogv2"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+func cachedClient(t *testing.T, h http.HandlerFunc) (*catalogv2.Client, *miniredis.Miniredis) {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	return catalogv2.New(srv.URL, "nmk_test_abcdefghijklmnopqrstuvwx12").WithRedis(rdb), mr
+}
+
+func emptyWorkList(w http.ResponseWriter) {
+	_ = json.NewEncoder(w).Encode(map[string]any{"object": "list", "items": []any{}, "total": 0})
+}
+
+func TestCalendarIsServedFromCacheOnTheSecondRead(t *testing.T) {
+	hits := 0
+	c, mr := cachedClient(t, func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		emptyWorkList(w)
+	})
+	ctx := context.Background()
+	for range 3 {
+		if _, err := c.Calendar(ctx, "2026-09", false, "", 100); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if hits != 1 {
+		t.Fatalf("upstream hits = %d, want 1", hits)
+	}
+	if len(mr.Keys()) != 1 {
+		t.Fatalf("cache keys = %v", mr.Keys())
+	}
+	if ttl := mr.TTL(mr.Keys()[0]); ttl != 60*time.Second {
+		t.Fatalf("list TTL = %v, want 60s", ttl)
+	}
+}
+
+// The whole cache rests on this: the S2S GET path sends no header that varies by
+// caller, so the URL is the identity of the response. If a face ever stopped
+// spelling its content limit into the query, an NSFW body would be handed to a
+// reader who asked for the SFW one.
+func TestContentLimitsNeverShareACacheKey(t *testing.T) {
+	var seen []string
+	c, _ := cachedClient(t, func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.URL.Query().Get("nsfw"))
+		emptyWorkList(w)
+	})
+	ctx := context.Background()
+	for range 2 {
+		if _, err := c.Calendar(ctx, "2026-09", false, "", 100); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := c.Calendar(ctx, "2026-09", true, "", 100); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(seen) != 2 || seen[0] != "false" || seen[1] != "true" {
+		t.Fatalf("upstream saw %v, want exactly one false and one true", seen)
+	}
+}
+
+func TestDetailReadsGetTheShortTTL(t *testing.T) {
+	c, mr := cachedClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"object": "company", "id": "7", "display_name": "Key"})
+	})
+	if _, err := c.GetCompany(context.Background(), 7, false); err != nil {
+		t.Fatal(err)
+	}
+	if len(mr.Keys()) != 1 {
+		t.Fatalf("cache keys = %v", mr.Keys())
+	}
+	if ttl := mr.TTL(mr.Keys()[0]); ttl != 15*time.Second {
+		t.Fatalf("detail TTL = %v, want 15s", ttl)
+	}
+}
+
+// claim-events drives an incremental cursor loop and proposals is what an editor
+// reloads after submitting an edit; a cached page on either is a correctness
+// bug, not a stale render.
+func TestCursorAndEditorLanesAreNeverCached(t *testing.T) {
+	hits := 0
+	c, mr := cachedClient(t, func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		_ = json.NewEncoder(w).Encode(map[string]any{"object": "list", "items": []any{}, "total": 0})
+	})
+	ctx := context.Background()
+	for range 2 {
+		if _, err := c.ClaimEvents(ctx, 0, 50, "moyu"); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := c.MergedProposalTotal(ctx, 11, "moyu"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if hits != 4 {
+		t.Fatalf("upstream hits = %d, want 4 — an excluded lane was cached", hits)
+	}
+	if len(mr.Keys()) != 0 {
+		t.Fatalf("cache keys = %v, want none", mr.Keys())
+	}
+}
+
+func TestAClientWithoutRedisStillReads(t *testing.T) {
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		emptyWorkList(w)
+	}))
+	t.Cleanup(srv.Close)
+	c := catalogv2.New(srv.URL, "nmk_test_abcdefghijklmnopqrstuvwx12")
+	for range 2 {
+		if _, err := c.Calendar(context.Background(), "2026-09", false, "", 100); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if hits != 2 {
+		t.Fatalf("upstream hits = %d, want 2", hits)
+	}
+}
+
+// An unconfigured deployment carries a nil *Client and expects ErrNotConfigured
+// from every read; the first cut of the cache dereferenced the receiver before
+// that check and panicked inside the fiber handler instead.
+func TestANilClientStillReturnsNotConfigured(t *testing.T) {
+	var c *catalogv2.Client
+	if _, err := c.GetSchema(context.Background(), "work"); !errors.Is(err, catalogv2.ErrNotConfigured) {
+		t.Fatalf("err = %v, want ErrNotConfigured", err)
+	}
+}

--- a/apps/api/pkg/catalogv2/client.go
+++ b/apps/api/pkg/catalogv2/client.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/redis/go-redis/v9"
 )
 
 var (
@@ -61,6 +63,7 @@ type Client struct {
 	http   *http.Client
 	origin string
 	apiKey string
+	rdb    *redis.Client
 }
 
 func New(baseURL, apiKey string) *Client {
@@ -90,9 +93,24 @@ func (c *Client) Configured() bool {
 	return c != nil && c.origin != "" && c.apiKey != ""
 }
 
+// Every S2S read goes through here, so this is where the shared read cache
+// belongs; user-token reads take userDo and are never cached. Decoding into a
+// json.RawMessage is what makes one body serve both the cache and the caller:
+// do() hands the verbatim bytes back without a second request, and a 204 or an
+// empty body leaves raw nil, exactly as before.
 func (c *Client) get(ctx context.Context, path string, out any) error {
-	_, err := c.do(ctx, http.MethodGet, path, "", "", nil, out)
-	return err
+	if body, ok := c.cacheGet(ctx, path); ok {
+		return json.Unmarshal(body, out)
+	}
+	var raw json.RawMessage
+	if _, err := c.do(ctx, http.MethodGet, path, "", "", nil, &raw); err != nil {
+		return err
+	}
+	if len(raw) == 0 {
+		return nil
+	}
+	c.cacheSet(ctx, path, raw)
+	return json.Unmarshal(raw, out)
 }
 
 func (c *Client) do(ctx context.Context, method, path, userToken, ifMatch string, body any, out any) (string, error) {


### PR DESCRIPTION
## Why

The 2026-09-02 capacity attribution named moyu's `/galgame/calendar` as the **single most expensive face in the whole Postgres cluster** (three statements, ~5,531s over 8h). The forum shipped a redis read cache in front of its own catalog client that day. Five days of metering, per client, from `developer_api_usage`:

| `/v2/catalog/calendar`, calls/day | 09-01 | 09-02 | 09-06 |
|---|---|---|---|
| forum (cache shipped 09-02) | 67,264 | 3,601 | 4,008 |
| **moyu (no cache)** | 54,674 | 50,166 | **32,149** |

The forum's own lane fell 95% and stayed down; moyu's did not move, so moyu is now the only remaining driver of that face. Same fix, one client further down.

## What

The cache lands in `catalogv2.Client.get`, which is the single S2S read path — user-token reads take `userDo` and are never touched. moyu's client decodes into typed structs rather than returning bytes, so `get` decodes into a `json.RawMessage` first and hands the same bytes to both the cache and the caller; a 204 or empty body leaves it nil and behaves exactly as before.

TTLs match the forum: **60s** for a list face, **15s** for one with a numeric id segment.

**An allowlist, not a list of exclusions.** The lanes that must never be cached are precisely the ones a later reader would forget to exclude:

- `/v2/catalog/changes` and `/v2/catalog/claim-events` drive incremental cursor loops — a stale page silently skips a window rather than rendering something old.
- `/v2/catalog/proposals` is what an editor reloads to see the edit they just submitted.

## What makes it safe

The S2S GET path sets no request header that varies by caller (`Authorization` is the constant service key; there is no content-limit header), so **the URL alone identifies the response**. Every face spells the content limit into the query as an explicit `nsfw=true` / `nsfw=false` — never omitted for the SFW case — so two readers with different limits cannot collide on a key. `TestContentLimitsNeverShareACacheKey` asserts that property directly instead of trusting it.

## Verification

`go build ./...` and the full `apps/api` suite green (19 packages). Two tests were confirmed red without their guard rather than merely green with it:

- dropping the allowlist → `upstream hits = 2, want 4 — an excluded lane was cached`
- the first cut of `cacheGet` dereferenced the receiver before the nil check and **panicked inside the fiber handler** (`internal/patch/handler` caught it). `Configured()` is written `c != nil && ...` on purpose, so an unconfigured deployment carries a nil client and expects `ErrNotConfigured`; `TestANilClientStillReturnsNotConfigured` now pins that.

No migration, no new configuration — it reuses the redis the app already connects to, and a client built without it (tests, one-off tools) behaves exactly as before.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD
