### PR TITLE
feat(folder): favourites become catalog folders, and this site gets folders

### DIFF
--- a/apps/api/internal/app/router.go
+++ b/apps/api/internal/app/router.go
@@ -79,6 +79,8 @@ func (a *App) RegisterRoutes() {
 		a.PatchHandler.GetResourceRevisions,
 	)
 	patchRoutes.Put("/:id/favorite", auth, a.PatchHandler.ToggleFavorite)
+	patchRoutes.Get("/:id/folder", auth, a.PatchHandler.FoldersForPatch)
+	patchRoutes.Put("/:id/folder", auth, a.PatchHandler.SetPatchFolders)
 
 	patchRoutes.Get("/:id/catalog-edit", auth, a.PatchHandler.CatalogEditBootstrap)
 	patchRoutes.Post("/:id/catalog-edit", auth, a.PatchHandler.CatalogEditSubmit)
@@ -112,6 +114,15 @@ func (a *App) RegisterRoutes() {
 	api.Post("/galgame/:gid/claim", auth, a.PatchHandler.ClaimGalgame)
 	api.Delete("/galgame/:gid", auth, a.PatchHandler.WithdrawGalgameSubmission)
 
+	// Folders are the catalog's, not this site's; these routes are a thin
+	// face over /v2/me/folders and /v2/folders carrying the reader's own token.
+	folderRoutes := api.Group("/folder")
+	folderRoutes.Get("", auth, a.PatchHandler.MyFolders)
+	folderRoutes.Post("", auth, a.PatchHandler.CreateFolder)
+	folderRoutes.Get("/:folderId", optionalAuth, a.PatchHandler.FolderDetail)
+	folderRoutes.Patch("/:folderId", auth, a.PatchHandler.UpdateFolder)
+	folderRoutes.Delete("/:folderId", auth, a.PatchHandler.DeleteFolder)
+
 	userRoutes := api.Group("/user")
 
 	userRoutes.Post("/check-in", auth, a.UserHandler.CheckIn)
@@ -126,6 +137,7 @@ func (a *App) RegisterRoutes() {
 	userRoutes.Get("/:id/patch", a.UserHandler.GetUserPatches)
 	userRoutes.Get("/:id/resource", a.UserHandler.GetUserResources)
 	userRoutes.Get("/:id/favorite", a.UserHandler.GetUserFavorites)
+	userRoutes.Get("/:id/folder", optionalAuth, a.PatchHandler.UserFolders)
 	userRoutes.Get("/:id/comment", a.UserHandler.GetUserComments)
 	userRoutes.Get("/:id/contribute", a.UserHandler.GetUserContributions)
 	userRoutes.Get("/:id/follower", optionalAuth, a.UserHandler.GetFollowers)

--- a/apps/api/internal/patch/handler/folders.go
+++ b/apps/api/internal/patch/handler/folders.go
@@ -1,0 +1,222 @@
+package handler
+
+import (
+	"strconv"
+	"strings"
+
+	"kun-galgame-patch-api/internal/middleware"
+	"kun-galgame-patch-api/pkg/catalogv2"
+	"kun-galgame-patch-api/pkg/errors"
+	"kun-galgame-patch-api/pkg/response"
+
+	"github.com/gofiber/fiber/v3"
+)
+
+const (
+	folderNameMax        = 60
+	folderDescriptionMax = 500
+)
+
+type folderWriteRequest struct {
+	Name        *string `json:"name"`
+	Description *string `json:"description"`
+	Visibility  *string `json:"visibility"`
+}
+
+type setFoldersRequest struct {
+	FolderIDs []int64 `json:"folder_ids"`
+}
+
+func folderIDParam(c fiber.Ctx) (int64, *errors.AppError) {
+	id, err := strconv.ParseInt(c.Params("folderId"), 10, 64)
+	if err != nil || id <= 0 {
+		return 0, errors.ErrBadRequest("无效的收藏夹 ID")
+	}
+	return id, nil
+}
+
+func validFolderWrite(in folderWriteRequest, nameRequired bool) *errors.AppError {
+	if in.Name != nil {
+		name := strings.TrimSpace(*in.Name)
+		if name == "" {
+			return errors.ErrValidation("收藏夹名称不能为空")
+		}
+		if len([]rune(name)) > folderNameMax {
+			return errors.ErrValidation("收藏夹名称过长")
+		}
+		*in.Name = name
+	} else if nameRequired {
+		return errors.ErrValidation("收藏夹名称不能为空")
+	}
+	if in.Description != nil && len([]rune(*in.Description)) > folderDescriptionMax {
+		return errors.ErrValidation("收藏夹简介过长")
+	}
+	if in.Visibility != nil &&
+		*in.Visibility != catalogv2.FolderVisibilityPublic &&
+		*in.Visibility != catalogv2.FolderVisibilityPrivate {
+		return errors.ErrValidation("未知的可见性")
+	}
+	return nil
+}
+
+func (h *PatchHandler) MyFolders(c fiber.Ctx) error {
+	token, appErr := catalogUserToken(c)
+	if appErr != nil {
+		return response.Error(c, appErr)
+	}
+	folders, err := h.service.MyFolders(c.Context(), token)
+	if err != nil {
+		return catalogErr(c, err, "读取收藏夹失败")
+	}
+	return response.OK(c, fiber.Map{"folders": folders})
+}
+
+func (h *PatchHandler) UserFolders(c fiber.Ctx) error {
+	ownerID, err := getIDParam(c, "id")
+	if err != nil {
+		return response.Error(c, err.(*errors.AppError))
+	}
+	// Somebody else's shelf shows only what they published. Their own shelf is
+	// MyFolders, which is the only face that knows about private folders.
+	if user := middleware.GetUser(c); user != nil && user.ID == ownerID {
+		if token := middleware.GetAccessToken(c); token != "" {
+			folders, mErr := h.service.MyFolders(c.Context(), token)
+			if mErr != nil {
+				return catalogErr(c, mErr, "读取收藏夹失败")
+			}
+			return response.OK(c, fiber.Map{"folders": folders})
+		}
+	}
+	folders, pErr := h.service.PublicFolders(c.Context(), ownerID)
+	if pErr != nil {
+		return catalogErr(c, pErr, "读取收藏夹失败")
+	}
+	return response.OK(c, fiber.Map{"folders": folders})
+}
+
+func (h *PatchHandler) CreateFolder(c fiber.Ctx) error {
+	token, appErr := catalogUserToken(c)
+	if appErr != nil {
+		return response.Error(c, appErr)
+	}
+	var req folderWriteRequest
+	if err := c.Bind().Body(&req); err != nil {
+		return response.Error(c, errors.ErrBadRequest("请求参数错误"))
+	}
+	if vErr := validFolderWrite(req, true); vErr != nil {
+		return response.Error(c, vErr)
+	}
+	visibility := catalogv2.FolderVisibilityPublic
+	if req.Visibility != nil {
+		visibility = *req.Visibility
+	}
+	description := ""
+	if req.Description != nil {
+		description = *req.Description
+	}
+	folder, err := h.service.CreateFolder(c.Context(), token, *req.Name, description, visibility)
+	if err != nil {
+		return catalogErr(c, err, "创建收藏夹失败")
+	}
+	return response.OK(c, folder)
+}
+
+func (h *PatchHandler) UpdateFolder(c fiber.Ctx) error {
+	token, appErr := catalogUserToken(c)
+	if appErr != nil {
+		return response.Error(c, appErr)
+	}
+	folderID, idErr := folderIDParam(c)
+	if idErr != nil {
+		return response.Error(c, idErr)
+	}
+	var req folderWriteRequest
+	if err := c.Bind().Body(&req); err != nil {
+		return response.Error(c, errors.ErrBadRequest("请求参数错误"))
+	}
+	if vErr := validFolderWrite(req, false); vErr != nil {
+		return response.Error(c, vErr)
+	}
+	if req.Name == nil && req.Description == nil && req.Visibility == nil {
+		return response.Error(c, errors.ErrBadRequest("没有要修改的内容"))
+	}
+	folder, err := h.service.UpdateFolder(c.Context(), token, folderID, catalogv2.FolderWrite{
+		Name: req.Name, Description: req.Description, Visibility: req.Visibility,
+	})
+	if err != nil {
+		return catalogErr(c, err, "更新收藏夹失败")
+	}
+	return response.OK(c, folder)
+}
+
+func (h *PatchHandler) DeleteFolder(c fiber.Ctx) error {
+	token, appErr := catalogUserToken(c)
+	if appErr != nil {
+		return response.Error(c, appErr)
+	}
+	folderID, idErr := folderIDParam(c)
+	if idErr != nil {
+		return response.Error(c, idErr)
+	}
+	if err := h.service.DeleteFolder(c.Context(), token, folderID); err != nil {
+		return catalogErr(c, err, "删除收藏夹失败")
+	}
+	return response.OK(c, fiber.Map{"deleted": true})
+}
+
+func (h *PatchHandler) FolderDetail(c fiber.Ctx) error {
+	folderID, idErr := folderIDParam(c)
+	if idErr != nil {
+		return response.Error(c, idErr)
+	}
+	token := middleware.GetAccessToken(c)
+	// Try the owner's lane first when there is a token: it is the only one that
+	// answers a private folder, and it 404s just the same when the reader is
+	// not the owner, so nothing leaks by attempting it.
+	folder, patches, err := h.service.FolderPatches(c.Context(), token, folderID, token != "")
+	if err != nil && token != "" {
+		folder, patches, err = h.service.FolderPatches(c.Context(), "", folderID, false)
+	}
+	if err != nil {
+		return catalogErr(c, err, "读取收藏夹失败")
+	}
+	return response.OK(c, fiber.Map{"folder": folder, "patches": patches})
+}
+
+func (h *PatchHandler) FoldersForPatch(c fiber.Ctx) error {
+	token, appErr := catalogUserToken(c)
+	if appErr != nil {
+		return response.Error(c, appErr)
+	}
+	id, err := getIDParam(c, "id")
+	if err != nil {
+		return response.Error(c, err.(*errors.AppError))
+	}
+	folders, fErr := h.service.FoldersForPatch(c.Context(), token, id)
+	if fErr != nil {
+		return catalogErr(c, fErr, "读取收藏夹失败")
+	}
+	return response.OK(c, fiber.Map{"folders": folders})
+}
+
+func (h *PatchHandler) SetPatchFolders(c fiber.Ctx) error {
+	token, appErr := catalogUserToken(c)
+	if appErr != nil {
+		return response.Error(c, appErr)
+	}
+	id, err := getIDParam(c, "id")
+	if err != nil {
+		return response.Error(c, err.(*errors.AppError))
+	}
+	var req setFoldersRequest
+	if bErr := c.Bind().Body(&req); bErr != nil {
+		return response.Error(c, errors.ErrBadRequest("请求参数错误"))
+	}
+	if len(req.FolderIDs) > catalogv2.FoldersPerUserMax {
+		return response.Error(c, errors.ErrBadRequest("收藏夹数量超出上限"))
+	}
+	if sErr := h.service.SetPatchFolders(c.Context(), token, id, req.FolderIDs); sErr != nil {
+		return catalogErr(c, sErr, "更新收藏失败")
+	}
+	return response.OK(c, fiber.Map{"favorited": len(req.FolderIDs) > 0})
+}

--- a/apps/api/internal/patch/handler/handler.go
+++ b/apps/api/internal/patch/handler/handler.go
@@ -195,7 +195,7 @@ func (h *PatchHandler) GetPatch(c fiber.Ctx) error {
 
 	card := h.withPurchaseLinks(headerCard{GalgameCard: *enriched})
 	if user := middleware.GetUser(c); user != nil {
-		card.IsFavorite = h.service.IsFavorited(user.ID, id)
+		card.IsFavorite = h.service.IsFavoritedInCatalog(c.Context(), middleware.GetAccessToken(c), id)
 	}
 	return response.OK(c, card)
 }
@@ -706,10 +706,13 @@ func (h *PatchHandler) ToggleFavorite(c fiber.Ctx) error {
 	}
 
 	user := middleware.MustGetUser(c)
-	favorited, err := h.service.ToggleFavorite(id, user.ID)
+	token, appErr := catalogUserToken(c)
+	if appErr != nil {
+		return response.Error(c, appErr)
+	}
+	favorited, err := h.service.ToggleFavoriteInCatalog(c.Context(), token, id, user.ID)
 	if err != nil {
-		slog.Error("ToggleFavorite failed", "patchID", id, "error", err)
-		return response.Error(c, errors.ErrInternal("收藏失败，请稍后重试"))
+		return catalogErr(c, err, "收藏失败，请稍后重试")
 	}
 
 	return response.OK(c, map[string]bool{"favorited": favorited})

--- a/apps/api/internal/patch/handler/handler.go
+++ b/apps/api/internal/patch/handler/handler.go
@@ -55,6 +55,13 @@ func catalogErr(c fiber.Ctx, err error, fallback string) error {
 	if stderrors.Is(err, catalogv2.ErrNotConfigured) {
 		return response.Error(c, errors.ErrInternal("资料库客户端未配置"))
 	}
+	if stderrors.Is(err, service.ErrNoCatalogWork) {
+		return response.Error(c, errors.ErrValidation(
+			"这个游戏还没有收录进资料库，暂时无法收藏或加入收藏夹"))
+	}
+	if stderrors.Is(err, gorm.ErrRecordNotFound) {
+		return response.Error(c, errors.ErrNotFound("patch not found"))
+	}
 	if stderrors.Is(err, catalogv2.ErrNoAccessToken) {
 		return response.Error(c, errors.ErrUnauthorized())
 	}

--- a/apps/api/internal/patch/model/model.go
+++ b/apps/api/internal/patch/model/model.go
@@ -64,11 +64,6 @@ func (j JSONArray) Value() (driver.Value, error) {
 type Patch struct {
 	ID                 int       `gorm:"primaryKey;autoIncrement" json:"id"`
 	VndbID             string    `gorm:"uniqueIndex;type:varchar(107);not null" json:"vndb_id"`
-	// The catalog work this game is, resolved from VndbID through the exact
-	// vndb anchor. NOT equal to ID — the two id spaces are unrelated, see
-	// migration 034. NULL for the `pending-<n>` placeholders, which have no
-	// work and therefore cannot be favourited.
-	CatalogWorkID *int64 `gorm:"column:catalog_work_id" json:"-"`
 	BID                *int      `gorm:"column:bid;uniqueIndex" json:"bid"`
 	Status             int       `gorm:"default:0" json:"status"`
 	Download           int       `gorm:"default:0" json:"download"`
@@ -81,6 +76,13 @@ type Patch struct {
 	ContributeCount    int       `gorm:"default:0" json:"contribute_count"`
 	CommentCount       int       `gorm:"default:0" json:"comment_count"`
 	ResourceCount      int       `gorm:"default:0" json:"resource_count"`
+
+	// The catalog work this game is, resolved from VndbID through the exact
+	// vndb anchor. NOT equal to ID — the two id spaces are unrelated, see
+	// migration 034. NULL for the `pending-<n>` placeholders, which have no
+	// work and therefore cannot be favourited. Not unique either: two pages for
+	// one game share a work, which is why the index is not UNIQUE.
+	CatalogWorkID *int64 `gorm:"column:catalog_work_id" json:"-"`
 
 	IsStub bool `gorm:"default:false" json:"-"`
 

--- a/apps/api/internal/patch/model/model.go
+++ b/apps/api/internal/patch/model/model.go
@@ -64,6 +64,11 @@ func (j JSONArray) Value() (driver.Value, error) {
 type Patch struct {
 	ID                 int       `gorm:"primaryKey;autoIncrement" json:"id"`
 	VndbID             string    `gorm:"uniqueIndex;type:varchar(107);not null" json:"vndb_id"`
+	// The catalog work this game is, resolved from VndbID through the exact
+	// vndb anchor. NOT equal to ID — the two id spaces are unrelated, see
+	// migration 034. NULL for the `pending-<n>` placeholders, which have no
+	// work and therefore cannot be favourited.
+	CatalogWorkID *int64 `gorm:"column:catalog_work_id" json:"-"`
 	BID                *int      `gorm:"column:bid;uniqueIndex" json:"bid"`
 	Status             int       `gorm:"default:0" json:"status"`
 	Download           int       `gorm:"default:0" json:"download"`

--- a/apps/api/internal/patch/repository/folder_repo.go
+++ b/apps/api/internal/patch/repository/folder_repo.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"kun-galgame-patch-api/internal/patch/model"
+	"kun-galgame-patch-api/pkg/utils"
 )
 
 // A `pending-<n>` placeholder has no vndb number and therefore no work. Its
@@ -28,21 +29,7 @@ func (r *PatchRepository) CatalogWorkID(patchID int) (int64, error) {
 }
 
 func (r *PatchRepository) PatchIDsByWorkIDs(workIDs []int64) (map[int64]int, error) {
-	out := map[int64]int{}
-	if len(workIDs) == 0 {
-		return out, nil
-	}
-	var rows []model.Patch
-	if err := r.db.Select("id, catalog_work_id").
-		Where("catalog_work_id IN ?", workIDs).Find(&rows).Error; err != nil {
-		return nil, err
-	}
-	for _, row := range rows {
-		if row.CatalogWorkID != nil {
-			out[*row.CatalogWorkID] = row.ID
-		}
-	}
-	return out, nil
+	return utils.PatchIDsByWorkIDs(r.db, workIDs)
 }
 
 func (r *PatchRepository) SetCatalogWorkID(patchID int, workID int64) error {

--- a/apps/api/internal/patch/repository/folder_repo.go
+++ b/apps/api/internal/patch/repository/folder_repo.go
@@ -1,0 +1,75 @@
+package repository
+
+import (
+	"errors"
+
+	"kun-galgame-patch-api/internal/patch/model"
+)
+
+// A `pending-<n>` placeholder has no vndb number and therefore no work. Its
+// favourites cannot travel to the catalog, and answering 0 would file them on
+// nothing, so the refusal is explicit.
+var ErrNoCatalogWork = errors.New("patch has no catalog work")
+
+// A folder item names a catalog WORK, and this site's patch.id is a different
+// id space (migration 034). Both directions are a local index lookup on
+// patch.catalog_work_id so a heart click costs no extra catalog call and
+// rendering "my favourites" stays one SQL query.
+
+func (r *PatchRepository) CatalogWorkID(patchID int) (int64, error) {
+	var row model.Patch
+	if err := r.db.Select("catalog_work_id").Where("id = ?", patchID).First(&row).Error; err != nil {
+		return 0, err
+	}
+	if row.CatalogWorkID == nil {
+		return 0, ErrNoCatalogWork
+	}
+	return *row.CatalogWorkID, nil
+}
+
+func (r *PatchRepository) PatchIDsByWorkIDs(workIDs []int64) (map[int64]int, error) {
+	out := map[int64]int{}
+	if len(workIDs) == 0 {
+		return out, nil
+	}
+	var rows []model.Patch
+	if err := r.db.Select("id, catalog_work_id").
+		Where("catalog_work_id IN ?", workIDs).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		if row.CatalogWorkID != nil {
+			out[*row.CatalogWorkID] = row.ID
+		}
+	}
+	return out, nil
+}
+
+func (r *PatchRepository) SetCatalogWorkID(patchID int, workID int64) error {
+	return r.db.Model(&model.Patch{}).Where("id = ?", patchID).
+		Update("catalog_work_id", workID).Error
+}
+
+// PatchesByIDsOrdered keeps the order the caller asked for. The folder decides
+// the order — newest added first — and an `IN (?)` would hand back whatever
+// the planner felt like.
+func (r *PatchRepository) PatchesByIDsOrdered(ids []int) ([]model.Patch, error) {
+	out := []model.Patch{}
+	if len(ids) == 0 {
+		return out, nil
+	}
+	var rows []model.Patch
+	if err := r.db.Where("id IN ?", ids).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	byID := make(map[int]model.Patch, len(rows))
+	for _, row := range rows {
+		byID[row.ID] = row
+	}
+	for _, id := range ids {
+		if row, ok := byID[id]; ok {
+			out = append(out, row)
+		}
+	}
+	return out, nil
+}

--- a/apps/api/internal/patch/service/folders.go
+++ b/apps/api/internal/patch/service/folders.go
@@ -6,8 +6,17 @@ import (
 	"sort"
 
 	"kun-galgame-patch-api/internal/patch/model"
+	"kun-galgame-patch-api/internal/patch/repository"
 	"kun-galgame-patch-api/pkg/catalogv2"
 )
+
+// ErrNoCatalogWork is the repository's sentinel, re-exported so the handler can
+// map it without reaching past the service. 84 patches carry no work — 78
+// `pending-<n>` placeholders plus 13 v-numbers the catalog has never anchored —
+// and 76 of them are published with resources, so this is a real button people
+// press. Left unmapped it fell through to a 500 "please try again later" for a
+// condition that will never succeed on a retry.
+var ErrNoCatalogWork = repository.ErrNoCatalogWork
 
 // Favourites live in the catalog. This site never had folders — a favourite
 // was one row in user_patch_favorite_relation — and the 2026-09-07 backfill

--- a/apps/api/internal/patch/service/folders.go
+++ b/apps/api/internal/patch/service/folders.go
@@ -1,0 +1,345 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"kun-galgame-patch-api/internal/patch/model"
+	"kun-galgame-patch-api/pkg/catalogv2"
+)
+
+// Favourites live in the catalog. This site never had folders — a favourite
+// was one row in user_patch_favorite_relation — and the 2026-09-07 backfill
+// moved all 61,796 of them into each person's DEFAULT catalog folder. So the
+// heart button keeps meaning exactly what it meant: in or out of the default
+// folder. Folders are the new part on top.
+//
+// user_patch_favorite_relation is frozen from the cutover as rollback material
+// and is read by nothing.
+
+type FolderView struct {
+	ID          int64  `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Visibility  string `json:"visibility"`
+	IsDefault   bool   `json:"is_default"`
+	ItemCount   int    `json:"item_count"`
+	Created     string `json:"created"`
+	Updated     string `json:"updated"`
+}
+
+type FolderMembership struct {
+	FolderView
+	Contains bool `json:"contains"`
+}
+
+func folderView(f catalogv2.Folder) FolderView {
+	return FolderView{
+		ID: f.ID, Name: f.Name, Description: f.Description, Visibility: f.Visibility,
+		IsDefault: f.IsDefault, ItemCount: f.ItemCount,
+		Created: f.CreatedAt, Updated: f.UpdatedAt,
+	}
+}
+
+// sortFolders puts the default folder first and then the most recently
+// touched, which is the order a person reads their own shelf in. The catalog
+// answers id-ascending because that keyset is a sync watermark.
+func sortFolders(rows []catalogv2.Folder) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].IsDefault != rows[j].IsDefault {
+			return rows[i].IsDefault
+		}
+		return rows[i].UpdatedAt > rows[j].UpdatedAt
+	})
+}
+
+func (s *PatchService) workIDOf(patchID int) (int64, error) {
+	return s.repo.CatalogWorkID(patchID)
+}
+
+func (s *PatchService) MyFolders(ctx context.Context, token string) ([]FolderView, error) {
+	rows, err := s.galgame.V2().MyFolders(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+	sortFolders(rows)
+	out := make([]FolderView, 0, len(rows))
+	for _, f := range rows {
+		out = append(out, folderView(f))
+	}
+	return out, nil
+}
+
+func (s *PatchService) PublicFolders(ctx context.Context, ownerUID int) ([]FolderView, error) {
+	rows, err := s.galgame.V2().PublicFolders(ctx, int64(ownerUID))
+	if err != nil {
+		return nil, err
+	}
+	sortFolders(rows)
+	out := make([]FolderView, 0, len(rows))
+	for _, f := range rows {
+		out = append(out, folderView(f))
+	}
+	return out, nil
+}
+
+func (s *PatchService) CreateFolder(ctx context.Context, token, name, description, visibility string) (*FolderView, error) {
+	f, err := s.galgame.V2().CreateFolder(ctx, token, catalogv2.FolderWrite{
+		Name: &name, Description: &description, Visibility: &visibility,
+	})
+	if err != nil {
+		return nil, err
+	}
+	v := folderView(*f)
+	return &v, nil
+}
+
+func (s *PatchService) UpdateFolder(ctx context.Context, token string, folderID int64, in catalogv2.FolderWrite) (*FolderView, error) {
+	f, err := s.galgame.V2().PatchFolder(ctx, token, folderID, in)
+	if err != nil {
+		return nil, err
+	}
+	v := folderView(*f)
+	return &v, nil
+}
+
+func (s *PatchService) DeleteFolder(ctx context.Context, token string, folderID int64) error {
+	return s.galgame.V2().DeleteFolder(ctx, token, folderID)
+}
+
+// FolderPatches turns a folder's work ids back into this site's patches. Works
+// this site does not carry are dropped rather than rendered as holes: a person
+// can favourite a game on the forum that has no patch page here, and the
+// folder is shared between the two.
+func (s *PatchService) FolderPatches(ctx context.Context, token string, folderID int64, viewerIsOwner bool) (*FolderView, []model.Patch, error) {
+	var (
+		folder *catalogv2.Folder
+		items  []catalogv2.FolderItem
+		err    error
+	)
+	if viewerIsOwner && token != "" {
+		if folder, err = s.galgame.V2().MyFolder(ctx, token, folderID); err == nil {
+			items, err = s.galgame.V2().MyFolderItems(ctx, token, folderID)
+		}
+	} else {
+		if folder, err = s.galgame.V2().PublicFolder(ctx, folderID); err == nil {
+			items, err = s.galgame.V2().PublicFolderItems(ctx, folderID)
+		}
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Newest added first, which is what a shelf shows. The catalog's own order
+	// is the updated_at watermark and is not a reading order.
+	sort.SliceStable(items, func(i, j int) bool { return items[i].CreatedAt > items[j].CreatedAt })
+	workIDs := make([]int64, 0, len(items))
+	for _, it := range items {
+		workIDs = append(workIDs, it.WorkID)
+	}
+	byWork, mErr := s.repo.PatchIDsByWorkIDs(workIDs)
+	if mErr != nil {
+		return nil, nil, mErr
+	}
+	ids := make([]int, 0, len(workIDs))
+	for _, w := range workIDs {
+		if pid, ok := byWork[w]; ok {
+			ids = append(ids, pid)
+		}
+	}
+	patches, pErr := s.repo.PatchesByIDsOrdered(ids)
+	if pErr != nil {
+		return nil, nil, pErr
+	}
+	v := folderView(*folder)
+	return &v, patches, nil
+}
+
+// FoldersForPatch is the add-to-folder picker: every folder the person owns,
+// each flagged with whether it already holds this game. The person's first
+// visit creates their default folder, because a site with a heart button and
+// no folder to put things in is not a state anyone chose.
+func (s *PatchService) FoldersForPatch(ctx context.Context, token string, patchID int) ([]FolderMembership, error) {
+	workID, err := s.workIDOf(patchID)
+	if err != nil {
+		return nil, err
+	}
+	folders, err := s.galgame.V2().MyFolders(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+	if len(folders) == 0 {
+		created, cErr := s.ensureDefaultFolder(ctx, token)
+		if cErr != nil {
+			return nil, cErr
+		}
+		folders = []catalogv2.Folder{*created}
+	}
+	holding, err := s.galgame.V2().MyFoldersHolding(ctx, token, workID)
+	if err != nil {
+		return nil, err
+	}
+	has := map[int64]bool{}
+	for _, f := range holding {
+		has[f.ID] = true
+	}
+	sortFolders(folders)
+	out := make([]FolderMembership, 0, len(folders))
+	for _, f := range folders {
+		out = append(out, FolderMembership{FolderView: folderView(f), Contains: has[f.ID]})
+	}
+	return out, nil
+}
+
+// SetPatchFolders makes the person's folders holding this game exactly the set
+// they asked for.
+func (s *PatchService) SetPatchFolders(ctx context.Context, token string, patchID int, targets []int64) error {
+	workID, err := s.workIDOf(patchID)
+	if err != nil {
+		return err
+	}
+	owned, err := s.galgame.V2().MyFolders(ctx, token)
+	if err != nil {
+		return err
+	}
+	mine := map[int64]bool{}
+	for _, f := range owned {
+		mine[f.ID] = true
+	}
+	want := map[int64]bool{}
+	for _, id := range targets {
+		if !mine[id] {
+			return fmt.Errorf("folder %d is not yours", id)
+		}
+		want[id] = true
+	}
+
+	holding, err := s.galgame.V2().MyFoldersHolding(ctx, token, workID)
+	if err != nil {
+		return err
+	}
+	current := map[int64]bool{}
+	for _, f := range holding {
+		current[f.ID] = true
+	}
+	for id := range want {
+		if !current[id] {
+			if err := s.galgame.V2().PutFolderItem(ctx, token, id, workID); err != nil {
+				return err
+			}
+		}
+	}
+	for id := range current {
+		if !want[id] {
+			if err := s.galgame.V2().DeleteFolderItem(ctx, token, id, workID); err != nil {
+				return err
+			}
+		}
+	}
+	s.settleFavoriteSideEffects(ctx, patchID, len(current) == 0 && len(want) > 0, len(current) > 0 && len(want) == 0)
+	return nil
+}
+
+func (s *PatchService) ensureDefaultFolder(ctx context.Context, token string) (*catalogv2.Folder, error) {
+	// Deliberately unnamed: the backfill wrote empty names for every default
+	// folder it created, and clients derive the label from the owner's name.
+	// Inventing one here would freeze a language into somebody else's view.
+	empty, isDefault := "", true
+	pub := catalogv2.FolderVisibilityPublic
+	return s.galgame.V2().CreateFolder(ctx, token, catalogv2.FolderWrite{
+		Name: &empty, Description: &empty, Visibility: &pub, IsDefault: &isDefault,
+	})
+}
+
+func (s *PatchService) defaultFolderID(ctx context.Context, token string) (int64, error) {
+	folders, err := s.galgame.V2().MyFolders(ctx, token)
+	if err != nil {
+		return 0, err
+	}
+	for _, f := range folders {
+		if f.IsDefault {
+			return f.ID, nil
+		}
+	}
+	// A person can end up with folders but no default — the flag moves, and a
+	// moderator may have deleted the folder that held it. Making one is
+	// cheaper than refusing the heart button.
+	created, cErr := s.ensureDefaultFolder(ctx, token)
+	if cErr != nil {
+		return 0, cErr
+	}
+	return created.ID, nil
+}
+
+// ToggleFavoriteInCatalog is the heart button. In means "in my default
+// folder"; out means "in none of my folders", so unfavouriting a game the
+// person also filed by hand removes it from those folders too — the button
+// says favourited, and it has to be able to make that false.
+func (s *PatchService) ToggleFavoriteInCatalog(ctx context.Context, token string, patchID, userID int) (bool, error) {
+	workID, err := s.workIDOf(patchID)
+	if err != nil {
+		return false, err
+	}
+	if _, err := s.ensureLocalPatch(ctx, patchID, userID); err != nil {
+		return false, fmt.Errorf("patch not found")
+	}
+
+	holding, err := s.galgame.V2().MyFoldersHolding(ctx, token, workID)
+	if err != nil {
+		return false, err
+	}
+	if len(holding) > 0 {
+		for _, f := range holding {
+			if dErr := s.galgame.V2().DeleteFolderItem(ctx, token, f.ID, workID); dErr != nil {
+				return false, dErr
+			}
+		}
+		s.settleFavoriteSideEffects(ctx, patchID, false, true)
+		return false, nil
+	}
+
+	folderID, err := s.defaultFolderID(ctx, token)
+	if err != nil {
+		return false, err
+	}
+	if err := s.galgame.V2().PutFolderItem(ctx, token, folderID, workID); err != nil {
+		return false, err
+	}
+	s.settleFavoriteSideEffects(ctx, patchID, true, false)
+	return true, nil
+}
+
+func (s *PatchService) IsFavoritedInCatalog(ctx context.Context, token string, patchID int) bool {
+	if token == "" {
+		return false
+	}
+	workID, err := s.workIDOf(patchID)
+	if err != nil {
+		return false
+	}
+	holding, err := s.galgame.V2().MyFoldersHolding(ctx, token, workID)
+	return err == nil && len(holding) > 0
+}
+
+// The local counter and the author's moemoepoints follow the upstream write,
+// never precede it. patch.favorite_count backs this site's own sorting; the
+// number a reader sees on a game page comes from the catalog's
+// nextmoe/favorites row, which counts people across every site.
+func (s *PatchService) settleFavoriteSideEffects(ctx context.Context, patchID int, added, removed bool) {
+	if !added && !removed {
+		return
+	}
+	delta := 1
+	if removed {
+		delta = -1
+	}
+	s.repo.UpdateCount(patchID, "favorite_count", delta)
+
+	patch, err := s.repo.GetPatchDetail(patchID)
+	if err != nil || patch == nil || patch.UserID == 0 {
+		return
+	}
+	go s.mp.Award(context.WithoutCancel(ctx), patch.UserID, delta, "liked",
+		fmt.Sprintf("galgame:%d", patchID), fmt.Sprintf("moyu:favorite:%d:%d", patchID, delta))
+}

--- a/apps/api/internal/patch/service/service.go
+++ b/apps/api/internal/patch/service/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand"
+	"strconv"
 	"strings"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"kun-galgame-patch-api/internal/patch/repository"
 	settingService "kun-galgame-patch-api/internal/setting/service"
 	"kun-galgame-patch-api/pkg/artifactclient"
+	"kun-galgame-patch-api/pkg/catalogv2"
 	"kun-galgame-patch-api/pkg/moemoepoint"
 	"kun-galgame-patch-api/pkg/userclient"
 	"kun-galgame-patch-api/pkg/utils"
@@ -67,6 +69,30 @@ func (s *PatchService) CreatePatchByGalgameID(ctx context.Context, userID, galga
 	return s.createPatchRow(ctx, userID, galgameID, vndb)
 }
 
+// resolveCatalogWork turns this site's vndb id into a catalog work. A
+// `wiki-<n>` id is a catalog work id with a prefix — that is what it was
+// minted from — and a `pending-<n>` placeholder has no work at all.
+func (s *PatchService) resolveCatalogWork(ctx context.Context, vndbID string) *int64 {
+	if rest, cut := strings.CutPrefix(vndbID, "wiki-"); cut {
+		if n, err := strconv.ParseInt(rest, 10, 64); err == nil && n > 0 {
+			return &n
+		}
+		return nil
+	}
+	if !strings.HasPrefix(vndbID, "v") {
+		return nil
+	}
+	w, err := s.galgame.V2().WorkByRef(ctx, "vndb", vndbID, true)
+	if err != nil || w == nil {
+		return nil
+	}
+	n, ok := catalogv2.ParseID(w.ID)
+	if !ok {
+		return nil
+	}
+	return &n
+}
+
 func (s *PatchService) createPatchRow(ctx context.Context, userID, galgameID int, vndbID string) (int, error) {
 	if existing, _ := s.repo.GetPatchDetail(galgameID); existing != nil && existing.ID != 0 {
 		if existing.IsStub {
@@ -80,13 +106,21 @@ func (s *PatchService) createPatchRow(ctx context.Context, userID, galgameID int
 		releaseDate = utils.ParseGalgameReleaseDate(*env.Galgame.ReleaseDate)
 	}
 
+	// Without this a game created after the folder cutover cannot be
+	// favourited: a folder item names a catalog work and patch.id is a
+	// different id space (migration 034). Resolution is best effort — a
+	// `pending-<n>` placeholder has no work yet — and the backfill script
+	// picks up whatever was missed.
+	workID := s.resolveCatalogWork(ctx, vndbID)
+
 	var patchID int
 	txErr := s.db.Transaction(func(tx *gorm.DB) error {
 		p := &model.Patch{
-			ID:          galgameID,
-			VndbID:      vndbID,
-			UserID:      userID,
-			ReleaseDate: releaseDate,
+			ID:            galgameID,
+			VndbID:        vndbID,
+			UserID:        userID,
+			ReleaseDate:   releaseDate,
+			CatalogWorkID: workID,
 		}
 		if err := tx.Create(p).Error; err != nil {
 			return fmt.Errorf("创建 patch 失败: %w", err)
@@ -1037,46 +1071,10 @@ func (s *PatchService) IsResourceFavorited(userID, resourceID int) bool {
 	return err == nil
 }
 
-func (s *PatchService) ToggleFavorite(patchID, userID int) (bool, error) {
-	patch, err := s.ensureLocalPatch(context.Background(), patchID, userID)
-	if err != nil {
-		return false, fmt.Errorf("patch not found")
-	}
-
-	existing, err := s.repo.FindFavorite(userID, patchID)
-	if err == nil {
-		if delErr := s.repo.DeleteFavorite(existing.ID); delErr != nil {
-			return false, delErr
-		}
-		s.repo.UpdateCount(patchID, "favorite_count", -1)
-		if patch.UserID != userID {
-			go s.mp.Award(context.Background(), patch.UserID, -1, "liked",
-				fmt.Sprintf("galgame:%d", patchID), fmt.Sprintf("moyu:unfavorite:%d", existing.ID))
-		}
-		return false, nil
-	}
-	if !errors.Is(err, gorm.ErrRecordNotFound) {
-		return false, err
-	}
-
-	rel := &model.UserPatchFavoriteRelation{UserID: userID, GalgameID: patchID}
-	if err := s.repo.CreateFavorite(rel); err != nil {
-		return false, err
-	}
-	s.repo.UpdateCount(patchID, "favorite_count", 1)
-	if patch.UserID != userID {
-		go s.mp.Award(context.Background(), patch.UserID, 1, "liked",
-			fmt.Sprintf("galgame:%d", patchID), fmt.Sprintf("moyu:favorite:%d", rel.ID))
-		go s.notifyContentInteraction(userID, patch.UserID, patchID,
-			"favorite", fmt.Sprintf("/patch/%d/introduction", patchID))
-	}
-	return true, nil
-}
-
-func (s *PatchService) IsFavorited(userID, patchID int) bool {
-	_, err := s.repo.FindFavorite(userID, patchID)
-	return err == nil
-}
+// ToggleFavorite and IsFavorited used to read and write
+// user_patch_favorite_relation. Favourites are catalog folder memberships
+// since the cutover; see service/folders.go. The table is frozen as rollback
+// material and read by nothing.
 
 func (s *PatchService) GetContributorIDs(patchID int) ([]int, error) {
 	return s.repo.GetContributorIDs(patchID)

--- a/apps/api/internal/user/handler/handler.go
+++ b/apps/api/internal/user/handler/handler.go
@@ -133,7 +133,10 @@ func (h *UserHandler) GetUserFavorites(c fiber.Ctx) error {
 	}
 
 	cl := utils.ContentLimitForListBrowse(c)
-	patches, total, err := h.service.GetUserFavorites(userID, req.Page, req.Limit, true, cl)
+	viewer := middleware.GetUser(c)
+	isOwner := viewer != nil && viewer.ID == userID
+	patches, total, err := h.service.GetUserFavorites(c.Context(), userID,
+		middleware.GetAccessToken(c), isOwner, req.Page, req.Limit, true, cl)
 	if err != nil {
 		return response.Error(c, errors.ErrInternal(""))
 	}

--- a/apps/api/internal/user/repository/repository.go
+++ b/apps/api/internal/user/repository/repository.go
@@ -75,11 +75,39 @@ func (r *UserRepository) GetUserResources(userID, offset, limit int) ([]patchMod
 	return resources, total, err
 }
 
-func (r *UserRepository) GetUserFavorites(userID, offset, limit int, includeEmpty bool, contentLimit string) ([]patchModel.Patch, int64, error) {
+// GetUserFavoritesByIDs is the old GetUserFavorites with its subquery replaced
+// by an id list. Favourites are catalog folder memberships since the cutover,
+// so the set arrives over HTTP; everything after that — the empty-patch
+// filter, the content-limit scope, the ordering and the paging — is the query
+// this site always ran, and is left alone.
+// A folder item names a catalog work; patch.id is a different id space
+// (migration 034). patch.catalog_work_id is the map, so this is one indexed
+// lookup rather than a resolution call per row.
+func (r *UserRepository) PatchIDsByWorkIDs(workIDs []int64) (map[int64]int, error) {
+	out := map[int64]int{}
+	if len(workIDs) == 0 {
+		return out, nil
+	}
+	var rows []patchModel.Patch
+	if err := r.db.Select("id, catalog_work_id").
+		Where("catalog_work_id IN ?", workIDs).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		if row.CatalogWorkID != nil {
+			out[*row.CatalogWorkID] = row.ID
+		}
+	}
+	return out, nil
+}
+
+func (r *UserRepository) GetUserFavoritesByIDs(patchIDs []int, offset, limit int, includeEmpty bool, contentLimit string) ([]patchModel.Patch, int64, error) {
+	if len(patchIDs) == 0 {
+		return []patchModel.Patch{}, 0, nil
+	}
 	var patches []patchModel.Patch
 	var total int64
-	subQuery := r.db.Table("user_patch_favorite_relation").Where("user_id = ?", userID).Select("galgame_id")
-	base := r.db.Model(&patchModel.Patch{}).Where("id IN (?)", subQuery)
+	base := r.db.Model(&patchModel.Patch{}).Where("id IN ?", patchIDs)
 	if !includeEmpty {
 		base = base.Where("resource_count > 0")
 	}

--- a/apps/api/internal/user/repository/repository.go
+++ b/apps/api/internal/user/repository/repository.go
@@ -84,21 +84,7 @@ func (r *UserRepository) GetUserResources(userID, offset, limit int) ([]patchMod
 // (migration 034). patch.catalog_work_id is the map, so this is one indexed
 // lookup rather than a resolution call per row.
 func (r *UserRepository) PatchIDsByWorkIDs(workIDs []int64) (map[int64]int, error) {
-	out := map[int64]int{}
-	if len(workIDs) == 0 {
-		return out, nil
-	}
-	var rows []patchModel.Patch
-	if err := r.db.Select("id, catalog_work_id").
-		Where("catalog_work_id IN ?", workIDs).Find(&rows).Error; err != nil {
-		return nil, err
-	}
-	for _, row := range rows {
-		if row.CatalogWorkID != nil {
-			out[*row.CatalogWorkID] = row.ID
-		}
-	}
-	return out, nil
+	return utils.PatchIDsByWorkIDs(r.db, workIDs)
 }
 
 func (r *UserRepository) GetUserFavoritesByIDs(patchIDs []int, offset, limit int, includeEmpty bool, contentLimit string) ([]patchModel.Patch, int64, error) {

--- a/apps/api/internal/user/service/service.go
+++ b/apps/api/internal/user/service/service.go
@@ -14,6 +14,7 @@ import (
 	"kun-galgame-patch-api/internal/user/dto"
 	"kun-galgame-patch-api/internal/user/model"
 	"kun-galgame-patch-api/internal/user/repository"
+	"kun-galgame-patch-api/pkg/catalogv2"
 	"kun-galgame-patch-api/pkg/moemoepoint"
 	"kun-galgame-patch-api/pkg/userclient"
 
@@ -302,8 +303,64 @@ func (s *UserService) GetUserResources(ctx context.Context, userID, page, limit 
 	return rs, total, nil
 }
 
-func (s *UserService) GetUserFavorites(userID, page, limit int, includeEmpty bool, contentLimit string) ([]patchModel.Patch, int64, error) {
-	return s.repo.GetUserFavorites(userID, (page-1)*limit, limit, includeEmpty, contentLimit)
+// GetUserFavorites reads the person's catalog folders and turns the works they
+// hold back into this site's patches. Their own shelf is read with their own
+// token so private folders count; anybody else sees only what they published.
+//
+// Works this site does not carry are dropped rather than shown as holes: the
+// folders are shared with the forum, where somebody can favourite a game that
+// has no patch page here.
+func (s *UserService) GetUserFavorites(ctx context.Context, userID int, token string, isOwner bool,
+	page, limit int, includeEmpty bool, contentLimit string) ([]patchModel.Patch, int64, error) {
+
+	var (
+		folders []catalogv2.Folder
+		err     error
+	)
+	if isOwner && token != "" {
+		folders, err = s.galgame.V2().MyFolders(ctx, token)
+	} else {
+		folders, err = s.galgame.V2().PublicFolders(ctx, int64(userID))
+	}
+	if err != nil {
+		return nil, 0, err
+	}
+
+	seen := map[int64]bool{}
+	workIDs := []int64{}
+	for _, f := range folders {
+		if f.ItemCount == 0 {
+			continue
+		}
+		var items []catalogv2.FolderItem
+		if isOwner && token != "" {
+			items, err = s.galgame.V2().MyFolderItems(ctx, token, f.ID)
+		} else {
+			items, err = s.galgame.V2().PublicFolderItems(ctx, f.ID)
+		}
+		if err != nil {
+			return nil, 0, err
+		}
+		for _, it := range items {
+			if seen[it.WorkID] {
+				continue
+			}
+			seen[it.WorkID] = true
+			workIDs = append(workIDs, it.WorkID)
+		}
+	}
+
+	byWork, mErr := s.repo.PatchIDsByWorkIDs(workIDs)
+	if mErr != nil {
+		return nil, 0, mErr
+	}
+	ids := make([]int, 0, len(workIDs))
+	for _, w := range workIDs {
+		if pid, ok := byWork[w]; ok {
+			ids = append(ids, pid)
+		}
+	}
+	return s.repo.GetUserFavoritesByIDs(ids, (page-1)*limit, limit, includeEmpty, contentLimit)
 }
 
 func (s *UserService) GetUserComments(ctx context.Context, userID, page, limit int) ([]patchModel.PatchComment, int64, error) {

--- a/apps/api/migrations/034_patch_catalog_work_id.down.sql
+++ b/apps/api/migrations/034_patch_catalog_work_id.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_patch_catalog_work;
+ALTER TABLE patch DROP COLUMN IF EXISTS catalog_work_id;

--- a/apps/api/migrations/034_patch_catalog_work_id.up.sql
+++ b/apps/api/migrations/034_patch_catalog_work_id.up.sql
@@ -17,5 +17,17 @@
 -- on work 0.
 ALTER TABLE patch ADD COLUMN IF NOT EXISTS catalog_work_id BIGINT;
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_patch_catalog_work
+-- NOT unique, and that was learned the hard way: this index shipped UNIQUE and
+-- the production backfill died on it —
+--   ERROR:  duplicate key value violates unique constraint "idx_patch_catalog_work"
+--   DETAIL:  Key (catalog_work_id)=(61311) already exists.
+-- Two works are each named by two patches, because this site dedupes on the
+-- vndb_id STRING and the same game reaches it under two spellings: patch 61311
+-- is `wiki-61311` while patch 61512 is `v65869`, and the catalog says those are
+-- one work. A unique index here asserts this site has no duplicate game pages,
+-- which is not this site's invariant to hold — the column points into somebody
+-- else's id space. Both rows keep the work id, so a heart on either page is the
+-- same favourite; PatchIDsByWorkIDs decides which page represents the work when
+-- the list is rendered back.
+CREATE INDEX IF NOT EXISTS idx_patch_catalog_work
   ON patch (catalog_work_id) WHERE catalog_work_id IS NOT NULL;

--- a/apps/api/migrations/034_patch_catalog_work_id.up.sql
+++ b/apps/api/migrations/034_patch_catalog_work_id.up.sql
@@ -1,0 +1,21 @@
+-- Favourites move to the catalog (nextmoe-infra /v2/me/folders). A folder item
+-- names a catalog WORK, and this site's patch.id is a different id space:
+-- measured 2026-09-07, the offset between the two is not constant (185 for
+-- 1,108 rows, 0 for 929, 4 for 907, 7 for 595, ...), so patch 923 and work 923
+-- are different games. The only correct mapping is the vndb number, which both
+-- sides already carry.
+--
+-- Resolving that per request would be an extra catalog call on every heart
+-- click and, worse, would have no reverse direction: rendering "my favourites"
+-- means turning a list of work ids back into patches, and work → vndb → patch
+-- is one call per row. The column makes both directions a local index lookup
+-- and lets the existing favourites query keep its SQL filtering and paging.
+--
+-- Nullable on purpose: 78 of 10,921 patches carry a `pending-<n>` placeholder
+-- instead of a vndb number and have no work to point at. Those cannot be
+-- favourited into the catalog and must fail loudly rather than silently land
+-- on work 0.
+ALTER TABLE patch ADD COLUMN IF NOT EXISTS catalog_work_id BIGINT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_patch_catalog_work
+  ON patch (catalog_work_id) WHERE catalog_work_id IS NOT NULL;

--- a/apps/api/pkg/catalogv2/folders.go
+++ b/apps/api/pkg/catalogv2/folders.go
@@ -1,0 +1,251 @@
+package catalogv2
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+// Mirrors the catalog's own caps. Both are refused upstream with 422; they are
+// repeated so this site can say so in its own words before spending a request.
+const (
+	FoldersPerUserMax = 200
+	FolderItemsMax    = 10_000
+)
+
+const (
+	FolderVisibilityPrivate = "private"
+	FolderVisibilityPublic  = "public"
+)
+
+const folderPageMax = 100
+
+// A whole list is read rather than paged through to the caller: the catalog's
+// keyset is an incremental-sync watermark ordered by updated_at, while this
+// site's faces are page-numbered and ordered for a reader. The shapes are
+// small — production p50 is 5 folders per person and 2 items per folder, p99
+// is 370 items — so sorting locally costs one request in the ordinary case.
+const folderWalkPages = FolderItemsMax/folderPageMax + 1
+
+type Folder struct {
+	ID          int64  `json:"id"`
+	OwnerUID    int64  `json:"owner_uid"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Visibility  string `json:"visibility"`
+	IsDefault   bool   `json:"is_default"`
+	ItemCount   int    `json:"item_count"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+type FolderItem struct {
+	FolderID  int64  `json:"folder_id"`
+	WorkID    int64  `json:"work_id"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+type folderWire struct {
+	ID          string `json:"id"`
+	OwnerUID    string `json:"owner_uid"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Visibility  string `json:"visibility"`
+	IsDefault   bool   `json:"is_default"`
+	ItemCount   int    `json:"item_count"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+type folderItemWire struct {
+	FolderID  string `json:"folder_id"`
+	WorkID    string `json:"work_id"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+func (f folderWire) view() Folder {
+	return Folder{
+		ID: parseIDOrZero(f.ID), OwnerUID: parseIDOrZero(f.OwnerUID), Name: f.Name,
+		Description: f.Description, Visibility: f.Visibility, IsDefault: f.IsDefault,
+		ItemCount: f.ItemCount, CreatedAt: f.CreatedAt, UpdatedAt: f.UpdatedAt,
+	}
+}
+
+func (i folderItemWire) view() FolderItem {
+	return FolderItem{
+		FolderID: parseIDOrZero(i.FolderID), WorkID: parseIDOrZero(i.WorkID),
+		CreatedAt: i.CreatedAt, UpdatedAt: i.UpdatedAt,
+	}
+}
+
+type FolderWrite struct {
+	Name        *string `json:"name,omitempty"`
+	Description *string `json:"description,omitempty"`
+	Visibility  *string `json:"visibility,omitempty"`
+	IsDefault   *bool   `json:"is_default,omitempty"`
+}
+
+func walkFolderPages[T any](ctx context.Context, fetch func(cursor string) (List[T], error)) ([]T, error) {
+	var out []T
+	cursor := ""
+	for page := 0; page < folderWalkPages; page++ {
+		got, err := fetch(cursor)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, got.Items...)
+		if got.NextCursor == nil || *got.NextCursor == "" || len(got.Items) == 0 {
+			return out, nil
+		}
+		cursor = *got.NextCursor
+	}
+	return out, nil
+}
+
+func folderQuery(cursor string, extra url.Values) string {
+	q := url.Values{}
+	for k, v := range extra {
+		q[k] = v
+	}
+	q.Set("limit", strconv.Itoa(folderPageMax))
+	if cursor != "" {
+		q.Set("cursor", cursor)
+	}
+	return "?" + q.Encode()
+}
+
+func (c *Client) MyFolders(ctx context.Context, accessToken string) ([]Folder, error) {
+	rows, err := walkFolderPages(ctx, func(cursor string) (List[folderWire], error) {
+		var page List[folderWire]
+		_, e := c.userDo(ctx, http.MethodGet, "/v2/me/folders"+folderQuery(cursor, nil), accessToken, nil, &page)
+		return page, e
+	})
+	return foldersView(rows), err
+}
+
+// MyFoldersHolding answers "which of my folders already hold this work" in one
+// request — the question the add-to-folder picker asks on every game page.
+func (c *Client) MyFoldersHolding(ctx context.Context, accessToken string, workID int64) ([]Folder, error) {
+	extra := url.Values{"contains_work_id": {strconv.FormatInt(workID, 10)}}
+	rows, err := walkFolderPages(ctx, func(cursor string) (List[folderWire], error) {
+		var page List[folderWire]
+		_, e := c.userDo(ctx, http.MethodGet, "/v2/me/folders"+folderQuery(cursor, extra), accessToken, nil, &page)
+		return page, e
+	})
+	return foldersView(rows), err
+}
+
+func (c *Client) MyFolderItems(ctx context.Context, accessToken string, folderID int64) ([]FolderItem, error) {
+	path := "/v2/me/folders/" + strconv.FormatInt(folderID, 10) + "/items"
+	rows, err := walkFolderPages(ctx, func(cursor string) (List[folderItemWire], error) {
+		var page List[folderItemWire]
+		_, e := c.userDo(ctx, http.MethodGet, path+folderQuery(cursor, nil), accessToken, nil, &page)
+		return page, e
+	})
+	return itemsView(rows), err
+}
+
+func (c *Client) MyFolder(ctx context.Context, accessToken string, folderID int64) (*Folder, error) {
+	var out folderWire
+	if _, err := c.userDo(ctx, http.MethodGet,
+		"/v2/me/folders/"+strconv.FormatInt(folderID, 10), accessToken, nil, &out); err != nil {
+		return nil, err
+	}
+	f := out.view()
+	return &f, nil
+}
+
+// The public lane takes the application key, not the reader's token: a public
+// folder is public to signed-out readers too, and folder:read is consent to
+// read the bearer's OWN folders, which says nothing about anybody else's.
+func (c *Client) PublicFolders(ctx context.Context, ownerUID int64) ([]Folder, error) {
+	extra := url.Values{"owner_uid": {strconv.FormatInt(ownerUID, 10)}}
+	rows, err := walkFolderPages(ctx, func(cursor string) (List[folderWire], error) {
+		var page List[folderWire]
+		e := c.get(ctx, "/v2/folders"+folderQuery(cursor, extra), &page)
+		return page, e
+	})
+	return foldersView(rows), err
+}
+
+func (c *Client) PublicFolder(ctx context.Context, folderID int64) (*Folder, error) {
+	var out folderWire
+	if err := c.get(ctx, "/v2/folders/"+strconv.FormatInt(folderID, 10), &out); err != nil {
+		return nil, err
+	}
+	f := out.view()
+	return &f, nil
+}
+
+func (c *Client) PublicFolderItems(ctx context.Context, folderID int64) ([]FolderItem, error) {
+	path := "/v2/folders/" + strconv.FormatInt(folderID, 10) + "/items"
+	rows, err := walkFolderPages(ctx, func(cursor string) (List[folderItemWire], error) {
+		var page List[folderItemWire]
+		e := c.get(ctx, path+folderQuery(cursor, nil), &page)
+		return page, e
+	})
+	return itemsView(rows), err
+}
+
+func (c *Client) CreateFolder(ctx context.Context, accessToken string, in FolderWrite) (*Folder, error) {
+	var out folderWire
+	if _, err := c.userDo(ctx, http.MethodPost, "/v2/me/folders", accessToken, in, &out); err != nil {
+		return nil, err
+	}
+	f := out.view()
+	return &f, nil
+}
+
+func (c *Client) PatchFolder(ctx context.Context, accessToken string, folderID int64, in FolderWrite) (*Folder, error) {
+	var out folderWire
+	if _, err := c.userDo(ctx, http.MethodPatch,
+		"/v2/me/folders/"+strconv.FormatInt(folderID, 10), accessToken, in, &out); err != nil {
+		return nil, err
+	}
+	f := out.view()
+	return &f, nil
+}
+
+func (c *Client) DeleteFolder(ctx context.Context, accessToken string, folderID int64) error {
+	_, err := c.userDo(ctx, http.MethodDelete,
+		"/v2/me/folders/"+strconv.FormatInt(folderID, 10), accessToken, nil, nil)
+	return err
+}
+
+func (c *Client) PutFolderItem(ctx context.Context, accessToken string, folderID, workID int64) error {
+	_, err := c.userDo(ctx, http.MethodPut,
+		"/v2/me/folders/"+strconv.FormatInt(folderID, 10)+"/items/"+strconv.FormatInt(workID, 10),
+		accessToken, nil, nil)
+	return err
+}
+
+func (c *Client) DeleteFolderItem(ctx context.Context, accessToken string, folderID, workID int64) error {
+	_, err := c.userDo(ctx, http.MethodDelete,
+		"/v2/me/folders/"+strconv.FormatInt(folderID, 10)+"/items/"+strconv.FormatInt(workID, 10),
+		accessToken, nil, nil)
+	return err
+}
+
+func parseIDOrZero(raw string) int64 {
+	n, _ := ParseID(raw)
+	return n
+}
+
+func foldersView(rows []folderWire) []Folder {
+	out := make([]Folder, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, r.view())
+	}
+	return out
+}
+
+func itemsView(rows []folderItemWire) []FolderItem {
+	out := make([]FolderItem, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, r.view())
+	}
+	return out
+}

--- a/apps/api/pkg/catalogv2/folders_test.go
+++ b/apps/api/pkg/catalogv2/folders_test.go
@@ -1,0 +1,286 @@
+package catalogv2
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type folderFace struct {
+	mu    sync.Mutex
+	hits  []folderCall
+	pages map[string][]string
+}
+
+type folderCall struct {
+	Method string
+	Path   string
+	Query  string
+	Auth   string
+}
+
+func (f *folderFace) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	seen := map[string]int{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		f.hits = append(f.hits, folderCall{
+			Method: r.Method, Path: r.URL.Path, Query: r.URL.RawQuery,
+			Auth: r.Header.Get("Authorization"),
+		})
+		n := seen[r.URL.Path]
+		seen[r.URL.Path]++
+		f.mu.Unlock()
+
+		bodies := f.pages[r.URL.Path]
+		if len(bodies) == 0 {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"code":"NOT_FOUND","status":404,"detail":"no"}`))
+			return
+		}
+		if n >= len(bodies) {
+			n = len(bodies) - 1
+		}
+		_, _ = w.Write([]byte(bodies[n]))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func (f *folderFace) calls() []folderCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]folderCall, len(f.hits))
+	copy(out, f.hits)
+	return out
+}
+
+func folderListBody(next string, ids ...int64) string {
+	items := make([]string, 0, len(ids))
+	for _, id := range ids {
+		items = append(items, `{"object":"folder","id":"`+strconv.FormatInt(id, 10)+
+			`","owner_uid":"7","name":"f","description":"","visibility":"public",`+
+			`"is_default":false,"item_count":1,"created_at":"2026-01-01T00:00:00Z",`+
+			`"updated_at":"2026-01-02T00:00:00Z"}`)
+	}
+	cursor := "null"
+	if next != "" {
+		cursor = `"` + next + `"`
+	}
+	return `{"object":"list","items":[` + strings.Join(items, ",") + `],"next_cursor":` + cursor + `}`
+}
+
+func itemListBody(next string, workIDs ...int64) string {
+	items := make([]string, 0, len(workIDs))
+	for _, id := range workIDs {
+		items = append(items, `{"object":"folder_item","folder_id":"5","work_id":"`+
+			strconv.FormatInt(id, 10)+`","created_at":"2026-01-01T00:00:00Z",`+
+			`"updated_at":"2026-01-01T00:00:00Z"}`)
+	}
+	cursor := "null"
+	if next != "" {
+		cursor = `"` + next + `"`
+	}
+	return `{"object":"list","items":[` + strings.Join(items, ",") + `],"next_cursor":` + cursor + `}`
+}
+
+// The two lanes take different credentials and that is the whole point: a
+// public folder is public to signed-out readers, while folder:read is consent
+// to read the bearer's OWN folders and says nothing about anybody else's.
+// Sending the wrong one is the shape of the cover-vote outage — a silent 403.
+func TestFolderLanesUseTheRightCredential(t *testing.T) {
+	face := &folderFace{pages: map[string][]string{
+		"/v2/me/folders":      {folderListBody("", 11)},
+		"/v2/folders":         {folderListBody("", 12)},
+		"/v2/folders/5/items": {itemListBody("", 900)},
+	}}
+	srv := face.server(t)
+	c := New(srv.URL, "nmk_live_key")
+	ctx := context.Background()
+
+	if _, err := c.MyFolders(ctx, "user-jwt"); err != nil {
+		t.Fatalf("MyFolders: %v", err)
+	}
+	if _, err := c.PublicFolders(ctx, 7); err != nil {
+		t.Fatalf("PublicFolders: %v", err)
+	}
+	if _, err := c.PublicFolderItems(ctx, 5); err != nil {
+		t.Fatalf("PublicFolderItems: %v", err)
+	}
+
+	for _, call := range face.calls() {
+		mine := strings.HasPrefix(call.Path, "/v2/me/")
+		switch {
+		case mine && call.Auth != "Bearer user-jwt":
+			t.Errorf("%s sent %q, want the user token", call.Path, call.Auth)
+		case !mine && !strings.Contains(call.Auth, "nmk_live_key"):
+			t.Errorf("%s sent %q, want the application key", call.Path, call.Auth)
+		}
+	}
+}
+
+func TestPublicFolderListCarriesTheOwner(t *testing.T) {
+	face := &folderFace{pages: map[string][]string{"/v2/folders": {folderListBody("", 11)}}}
+	srv := face.server(t)
+	c := New(srv.URL, "k")
+
+	if _, err := c.PublicFolders(context.Background(), 4242); err != nil {
+		t.Fatalf("PublicFolders: %v", err)
+	}
+	if q := face.calls()[0].Query; !strings.Contains(q, "owner_uid=4242") {
+		t.Fatalf("query %q carries no owner_uid — upstream answers 400 without it", q)
+	}
+}
+
+func TestFoldersHoldingSendsTheFilter(t *testing.T) {
+	face := &folderFace{pages: map[string][]string{"/v2/me/folders": {folderListBody("", 11)}}}
+	srv := face.server(t)
+	c := New(srv.URL, "k")
+
+	got, err := c.MyFoldersHolding(context.Background(), "tok", 900)
+	if err != nil {
+		t.Fatalf("MyFoldersHolding: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d folders", len(got))
+	}
+	if q := face.calls()[0].Query; !strings.Contains(q, "contains_work_id=900") {
+		t.Fatalf("query %q carries no contains_work_id — the picker would read every folder", q)
+	}
+}
+
+// The whole folder is read: the site orders and pages locally because the
+// catalog's keyset is a sync watermark, so a walk that stopped early would
+// silently drop the tail of a big folder.
+func TestFolderWalkFollowsEveryCursor(t *testing.T) {
+	face := &folderFace{pages: map[string][]string{
+		"/v2/me/folders/5/items": {
+			itemListBody("cur_a", 901, 902),
+			itemListBody("cur_b", 903),
+			itemListBody("", 904),
+		},
+	}}
+	srv := face.server(t)
+	c := New(srv.URL, "k")
+
+	items, err := c.MyFolderItems(context.Background(), "tok", 5)
+	if err != nil {
+		t.Fatalf("MyFolderItems: %v", err)
+	}
+	if len(items) != 4 {
+		t.Fatalf("walked %d items, want 4", len(items))
+	}
+	calls := face.calls()
+	if len(calls) != 3 {
+		t.Fatalf("made %d requests, want 3", len(calls))
+	}
+	if strings.Contains(calls[0].Query, "cursor=") {
+		t.Errorf("first page sent a cursor: %q", calls[0].Query)
+	}
+	if !strings.Contains(calls[1].Query, "cursor=cur_a") || !strings.Contains(calls[2].Query, "cursor=cur_b") {
+		t.Errorf("cursors not threaded: %q then %q", calls[1].Query, calls[2].Query)
+	}
+	if items[0].WorkID != 901 || items[3].WorkID != 904 {
+		t.Errorf("decoded work ids wrong: %+v", items)
+	}
+}
+
+func TestFolderWritesAddressTheRightRoutes(t *testing.T) {
+	body := `{"object":"folder","id":"5","owner_uid":"7","name":"n","description":"","visibility":"private","is_default":false,"item_count":0,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}`
+	face := &folderFace{pages: map[string][]string{
+		"/v2/me/folders":             {body},
+		"/v2/me/folders/5":           {body},
+		"/v2/me/folders/5/items/900": {`{}`},
+	}}
+	srv := face.server(t)
+	c := New(srv.URL, "k")
+	ctx := context.Background()
+	name := "n"
+
+	if _, err := c.CreateFolder(ctx, "tok", FolderWrite{Name: &name}); err != nil {
+		t.Fatalf("CreateFolder: %v", err)
+	}
+	if _, err := c.PatchFolder(ctx, "tok", 5, FolderWrite{Name: &name}); err != nil {
+		t.Fatalf("PatchFolder: %v", err)
+	}
+	if err := c.PutFolderItem(ctx, "tok", 5, 900); err != nil {
+		t.Fatalf("PutFolderItem: %v", err)
+	}
+	if err := c.DeleteFolderItem(ctx, "tok", 5, 900); err != nil {
+		t.Fatalf("DeleteFolderItem: %v", err)
+	}
+	if err := c.DeleteFolder(ctx, "tok", 5); err != nil {
+		t.Fatalf("DeleteFolder: %v", err)
+	}
+
+	want := []struct{ method, path string }{
+		{"POST", "/v2/me/folders"},
+		{"PATCH", "/v2/me/folders/5"},
+		{"PUT", "/v2/me/folders/5/items/900"},
+		{"DELETE", "/v2/me/folders/5/items/900"},
+		{"DELETE", "/v2/me/folders/5"},
+	}
+	calls := face.calls()
+	if len(calls) != len(want) {
+		t.Fatalf("made %d calls, want %d: %+v", len(calls), len(want), calls)
+	}
+	for i, w := range want {
+		if calls[i].Method != w.method || calls[i].Path != w.path {
+			t.Errorf("call %d was %s %s, want %s %s", i, calls[i].Method, calls[i].Path, w.method, w.path)
+		}
+	}
+}
+
+// A grant minted before folder:write was requested comes back 403
+// SCOPE_REQUIRED. The only cure is signing in again, and the handler maps it to
+// the re-login this site already had for catalog:edit, so it has to survive as
+// a Problem carrying the code.
+func TestFolderWriteSurfacesTheScopeRefusal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"code":"SCOPE_REQUIRED","status":403,` +
+			`"detail":"this operation requires the folder:write scope."}`))
+	}))
+	t.Cleanup(srv.Close)
+	c := New(srv.URL, "k")
+
+	name := "x"
+	_, err := c.CreateFolder(context.Background(), "tok", FolderWrite{Name: &name})
+	if err == nil {
+		t.Fatal("a scope refusal returned no error")
+	}
+	p, ok := err.(*Problem)
+	if !ok {
+		t.Fatalf("got %T (%v), want *Problem", err, err)
+	}
+	if p.Code != "SCOPE_REQUIRED" {
+		t.Fatalf("code %q, want SCOPE_REQUIRED", p.Code)
+	}
+}
+
+func TestFolderCreateOmitsUnsetFields(t *testing.T) {
+	var seen string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, 512)
+		n, _ := r.Body.Read(buf)
+		seen = string(buf[:n])
+		_, _ = w.Write([]byte(`{"object":"folder","id":"5","owner_uid":"7","name":"n","description":"","visibility":"private","is_default":false,"item_count":0,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}`))
+	}))
+	t.Cleanup(srv.Close)
+	c := New(srv.URL, "k")
+
+	name := "n"
+	if _, err := c.CreateFolder(context.Background(), "tok", FolderWrite{Name: &name}); err != nil {
+		t.Fatalf("CreateFolder: %v", err)
+	}
+	if strings.Contains(seen, "visibility") {
+		t.Errorf("an unset field was sent anyway: %s", seen)
+	}
+	if !strings.Contains(seen, `"name":"n"`) {
+		t.Errorf("name did not travel: %s", seen)
+	}
+}

--- a/apps/api/pkg/utils/catalogwork.go
+++ b/apps/api/pkg/utils/catalogwork.go
@@ -1,0 +1,46 @@
+package utils
+
+import "gorm.io/gorm"
+
+// patchWorkOrder is which page should represent a work when more than one patch
+// names it: published, then the one that actually carries patches, then a real
+// page over a stub, then the older id.
+const patchWorkOrder = "published DESC, resource_count DESC, is_stub ASC, id ASC"
+
+type patchWorkRow struct {
+	ID            int
+	CatalogWorkID int64
+}
+
+// PatchIDsByWorkIDs turns catalog work ids back into the patch that represents
+// each one.
+//
+// A work can be named by more than one patch. This site dedupes on the vndb_id
+// STRING, so a game that reaches it once as `wiki-<n>` and once as `v<n>` gets
+// two pages — production has two such pairs, and the unique index that first
+// shipped on patch.catalog_work_id died on one of them (migration 034). The
+// catalog files the favourite against the work, so a heart on either page is
+// the same favourite; only the rendering has to choose, and without the ORDER
+// BY the row it chose was whichever one the planner happened to return last.
+func PatchIDsByWorkIDs(db *gorm.DB, workIDs []int64) (map[int64]int, error) {
+	if len(workIDs) == 0 {
+		return map[int64]int{}, nil
+	}
+	var rows []patchWorkRow
+	if err := db.Table("patch").Select("id, catalog_work_id").
+		Where("catalog_work_id IN ?", workIDs).
+		Order(patchWorkOrder).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	return firstPerWork(rows), nil
+}
+
+func firstPerWork(rows []patchWorkRow) map[int64]int {
+	out := make(map[int64]int, len(rows))
+	for _, row := range rows {
+		if _, taken := out[row.CatalogWorkID]; !taken {
+			out[row.CatalogWorkID] = row.ID
+		}
+	}
+	return out
+}

--- a/apps/api/pkg/utils/catalogwork_test.go
+++ b/apps/api/pkg/utils/catalogwork_test.go
@@ -1,0 +1,58 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"gorm.io/gorm"
+)
+
+// Without an ORDER BY, which of two patches naming one work reached the map was
+// whatever the planner returned last — so the favourites list could show a
+// different page on every request.
+func TestPatchIDsByWorkIDsOrdersTheCandidates(t *testing.T) {
+	db := dryRunDB(t)
+	var rows []patchWorkRow
+	stmt := db.Table("patch").Select("id, catalog_work_id").
+		Where("catalog_work_id IN ?", []int64{61311}).
+		Order(patchWorkOrder).Session(&gorm.Session{DryRun: true}).Find(&rows).Statement
+	got := db.Dialector.Explain(stmt.SQL.String(), stmt.Vars...)
+
+	if !strings.Contains(got, "ORDER BY published DESC, resource_count DESC, is_stub ASC, id ASC") {
+		t.Fatalf("the tie-break never reached the wire: %q", got)
+	}
+}
+
+// The production pair that killed the unique index: patch 61311 is
+// `wiki-61311` and patch 61512 is `v65869`, and the catalog says both are work
+// 61311. 61311 is published and carries a patch; 61512 is neither, and holds
+// the three favourites — the favourite is on the game, so the reader is sent to
+// the page worth reading rather than the one they happened to star.
+func TestFirstPerWorkKeepsTheRepresentativePage(t *testing.T) {
+	got := firstPerWork([]patchWorkRow{
+		{ID: 61311, CatalogWorkID: 61311}, // published, 1 resource
+		{ID: 61512, CatalogWorkID: 61311}, // unpublished, 0 resources
+		{ID: 61533, CatalogWorkID: 61332}, // not a stub
+		{ID: 61332, CatalogWorkID: 61332}, // stub
+	})
+
+	if len(got) != 2 {
+		t.Fatalf("two works collapsed to %d entries: %v", len(got), got)
+	}
+	if got[61311] != 61311 {
+		t.Errorf("work 61311 rendered as patch %d, want 61311", got[61311])
+	}
+	if got[61332] != 61533 {
+		t.Errorf("work 61332 rendered as patch %d, want 61533", got[61332])
+	}
+}
+
+func TestPatchIDsByWorkIDsAnswersEmptyForNoWorks(t *testing.T) {
+	out, err := PatchIDsByWorkIDs(dryRunDB(t), nil)
+	if err != nil {
+		t.Fatalf("PatchIDsByWorkIDs: %v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("got %v, want an empty map", out)
+	}
+}

--- a/apps/api/scripts/backfill-patch-catalog-work-id.sql
+++ b/apps/api/scripts/backfill-patch-catalog-work-id.sql
@@ -1,0 +1,69 @@
+-- Fills patch.catalog_work_id from the catalog's exact vndb anchor — the same
+-- resolution nextmoe-infra's import-favorites used to place this site's 61,796
+-- flat favourites, so the column agrees with where those favourites landed.
+--
+-- Run after migration 034 and before deploying the folders feature. Run as a
+-- superuser with -f, in one psql session:
+--
+--   sudo docker exec -i <postgres> psql -U postgres -v ON_ERROR_STOP=1 \
+--     -f /path/to/backfill-patch-catalog-work-id.sql
+--
+-- link_kind 0 is the exact anchor; a probable anchor is a guess, and a guess
+-- that lands someone's favourite on the wrong game is worse than a game that
+-- cannot be favourited. entity_type 5 is the work — 1 is something else, and
+-- reading it gives a clean, wrong, empty answer.
+--
+-- Idempotent. `wiki-<n>` vndb ids are the catalog work id with a prefix and are
+-- resolved directly; `pending-<n>` placeholders have no work and stay NULL.
+
+\set ON_ERROR_STOP on
+\pset pager off
+
+\c kun_catalog
+\echo '=== exact vndb work anchors available'
+SELECT count(*) AS anchors, count(DISTINCT r.external_id) AS distinct_ids
+  FROM catalog_external_ref r JOIN catalog_source s ON s.id = r.source_id
+ WHERE s.key = 'vndb' AND r.entity_type = 5 AND r.link_kind = 0 AND r.dead_at IS NULL;
+
+\copy (SELECT r.external_id, r.entity_id FROM catalog_external_ref r JOIN catalog_source s ON s.id = r.source_id WHERE s.key = 'vndb' AND r.entity_type = 5 AND r.link_kind = 0 AND r.dead_at IS NULL) TO '/tmp/vndb_anchor.csv' CSV
+\copy (SELECT id FROM catalog_work WHERE status = 0) TO '/tmp/live_work.csv' CSV
+
+\c kungalgame_patch
+CREATE TEMP TABLE anchor (external_id TEXT PRIMARY KEY, work_id BIGINT NOT NULL);
+\copy anchor FROM '/tmp/vndb_anchor.csv' CSV
+CREATE TEMP TABLE live_work (id BIGINT PRIMARY KEY);
+\copy live_work FROM '/tmp/live_work.csv' CSV
+
+\echo '=== before'
+SELECT count(*) FILTER (WHERE catalog_work_id IS NOT NULL) AS mapped,
+       count(*) FILTER (WHERE catalog_work_id IS NULL) AS unmapped, count(*) AS total
+  FROM patch;
+
+BEGIN;
+-- v-numbers through the anchor
+UPDATE patch p SET catalog_work_id = a.work_id
+  FROM anchor a
+ WHERE a.external_id = p.vndb_id
+   AND p.catalog_work_id IS DISTINCT FROM a.work_id;
+
+-- wiki-<n> is the catalog work id with a prefix, kept only when that work is live
+UPDATE patch p SET catalog_work_id = w.id
+  FROM live_work w
+ WHERE p.vndb_id LIKE 'wiki-%'
+   AND w.id = substring(p.vndb_id from 6)::bigint
+   AND p.catalog_work_id IS DISTINCT FROM w.id;
+COMMIT;
+
+\echo '=== after, by vndb_id shape'
+SELECT CASE WHEN vndb_id LIKE 'v%' THEN 'v-number'
+            WHEN vndb_id LIKE 'wiki-%' THEN 'wiki-N'
+            WHEN vndb_id LIKE 'pending%' THEN 'pending (no work by design)'
+            ELSE 'other' END AS shape,
+       count(*) AS rows,
+       count(catalog_work_id) AS mapped
+  FROM patch GROUP BY 1 ORDER BY 1;
+
+\echo '=== favourited patches that still have no work (their favourites cannot migrate)'
+SELECT count(DISTINCT r.galgame_id)
+  FROM user_patch_favorite_relation r JOIN patch p ON p.id = r.galgame_id
+ WHERE p.catalog_work_id IS NULL;

--- a/apps/api/scripts/backfill-patch-catalog-work-id.sql
+++ b/apps/api/scripts/backfill-patch-catalog-work-id.sql
@@ -5,7 +5,7 @@
 -- Run after migration 034 and before deploying the folders feature. Run as a
 -- superuser with -f, in one psql session:
 --
---   sudo docker exec -i <postgres> psql -U postgres -v ON_ERROR_STOP=1 \
+--   sudo docker exec <postgres> psql -U postgres -v ON_ERROR_STOP=1 \
 --     -f /path/to/backfill-patch-catalog-work-id.sql
 --
 -- link_kind 0 is the exact anchor; a probable anchor is a guess, and a guess
@@ -13,26 +13,61 @@
 -- cannot be favourited. entity_type 5 is the work — 1 is something else, and
 -- reading it gives a clean, wrong, empty answer.
 --
--- Idempotent. `wiki-<n>` vndb ids are the catalog work id with a prefix and are
--- resolved directly; `pending-<n>` placeholders have no work and stay NULL.
+-- "Same resolution" is the whole contract, and the first version of this script
+-- broke it: import-favorites resolves work → follows catalog_redirect → then
+-- requires the target to be live, on BOTH shapes. This script checked liveness
+-- on `wiki-<n>` only and followed no redirect at all, so a v-number anchored to
+-- a since-merged work would have been stored as the merged id while the
+-- favourite sat on the survivor — the list would render nothing and the star
+-- would refuse. Every id written here is a live work, redirects followed.
+--
+-- Idempotent. `pending-<n>` placeholders have no work and stay NULL.
 
 \set ON_ERROR_STOP on
 \pset pager off
 
 \c kun_catalog
-\echo '=== exact vndb work anchors available'
-SELECT count(*) AS anchors, count(DISTINCT r.external_id) AS distinct_ids
+
+CREATE TEMP TABLE live AS SELECT id FROM catalog_work WHERE status = 0;
+ALTER TABLE live ADD PRIMARY KEY (id);
+
+-- A merged work's survivor. merge_rehang collapses chains, so depth > 1 is a
+-- guard against a chain that outlived one merge rather than an expected path —
+-- the same 8-hop ceiling the importer uses.
+CREATE TEMP TABLE survivor AS
+WITH RECURSIVE walk(start_id, cur, depth) AS (
+  SELECT old_id, current_id, 1 FROM catalog_redirect WHERE entity_type = 5
+  UNION ALL
+  SELECT w.start_id, r.current_id, w.depth + 1
+    FROM walk w JOIN catalog_redirect r ON r.old_id = w.cur AND r.entity_type = 5
+   WHERE w.depth < 8 AND r.current_id <> w.cur
+)
+SELECT DISTINCT ON (start_id) start_id, cur AS work_id
+  FROM walk WHERE cur IN (SELECT id FROM live)
+ ORDER BY start_id, depth;
+ALTER TABLE survivor ADD PRIMARY KEY (start_id);
+
+\echo '=== exact vndb work anchors, and how many survive the liveness rule'
+SELECT count(*) AS anchors,
+       count(*) FILTER (WHERE r.entity_id IN (SELECT id FROM live)) AS already_live,
+       count(*) FILTER (WHERE r.entity_id NOT IN (SELECT id FROM live)
+                          AND r.entity_id IN (SELECT start_id FROM survivor)) AS via_redirect,
+       count(*) FILTER (WHERE r.entity_id NOT IN (SELECT id FROM live)
+                          AND r.entity_id NOT IN (SELECT start_id FROM survivor)) AS dropped
   FROM catalog_external_ref r JOIN catalog_source s ON s.id = r.source_id
  WHERE s.key = 'vndb' AND r.entity_type = 5 AND r.link_kind = 0 AND r.dead_at IS NULL;
 
-\copy (SELECT r.external_id, r.entity_id FROM catalog_external_ref r JOIN catalog_source s ON s.id = r.source_id WHERE s.key = 'vndb' AND r.entity_type = 5 AND r.link_kind = 0 AND r.dead_at IS NULL) TO '/tmp/vndb_anchor.csv' CSV
-\copy (SELECT id FROM catalog_work WHERE status = 0) TO '/tmp/live_work.csv' CSV
+\copy (SELECT r.external_id, coalesce(sv.work_id, r.entity_id) AS work_id FROM catalog_external_ref r JOIN catalog_source s ON s.id = r.source_id LEFT JOIN survivor sv ON sv.start_id = r.entity_id WHERE s.key = 'vndb' AND r.entity_type = 5 AND r.link_kind = 0 AND r.dead_at IS NULL AND (r.entity_id IN (SELECT id FROM live) OR sv.work_id IS NOT NULL)) TO '/tmp/vndb_anchor.csv' CSV
+\copy (SELECT id FROM live) TO '/tmp/live_work.csv' CSV
+\copy (SELECT start_id, work_id FROM survivor) TO '/tmp/survivor.csv' CSV
 
 \c kungalgame_patch
 CREATE TEMP TABLE anchor (external_id TEXT PRIMARY KEY, work_id BIGINT NOT NULL);
 \copy anchor FROM '/tmp/vndb_anchor.csv' CSV
 CREATE TEMP TABLE live_work (id BIGINT PRIMARY KEY);
 \copy live_work FROM '/tmp/live_work.csv' CSV
+CREATE TEMP TABLE survivor (start_id BIGINT PRIMARY KEY, work_id BIGINT NOT NULL);
+\copy survivor FROM '/tmp/survivor.csv' CSV
 
 \echo '=== before'
 SELECT count(*) FILTER (WHERE catalog_work_id IS NOT NULL) AS mapped,
@@ -40,18 +75,27 @@ SELECT count(*) FILTER (WHERE catalog_work_id IS NOT NULL) AS mapped,
   FROM patch;
 
 BEGIN;
--- v-numbers through the anchor
-UPDATE patch p SET catalog_work_id = a.work_id
-  FROM anchor a
- WHERE a.external_id = p.vndb_id
-   AND p.catalog_work_id IS DISTINCT FROM a.work_id;
+-- A full re-derivation, not an append. A row this rule no longer maps has to
+-- LOSE the id an earlier run gave it: works get merged, anchors get marked
+-- dead, and a column that only ever gains values keeps pointing at a work that
+-- no longer exists. One transaction, so the column is never seen empty.
+UPDATE patch SET catalog_work_id = NULL WHERE catalog_work_id IS NOT NULL;
 
--- wiki-<n> is the catalog work id with a prefix, kept only when that work is live
-UPDATE patch p SET catalog_work_id = w.id
-  FROM live_work w
- WHERE p.vndb_id LIKE 'wiki-%'
-   AND w.id = substring(p.vndb_id from 6)::bigint
-   AND p.catalog_work_id IS DISTINCT FROM w.id;
+-- v-numbers through the anchor, which the export already resolved to a live work
+UPDATE patch p SET catalog_work_id = a.work_id
+  FROM anchor a WHERE a.external_id = p.vndb_id;
+
+-- `wiki-<n>` is a catalog work id with a prefix, written when this site adopted
+-- a work that had no vndb entry. The number is followed through the same
+-- redirect rule, then required to be live.
+UPDATE patch p SET catalog_work_id = t.work_id
+  FROM (SELECT p2.id AS patch_id,
+               coalesce(sv.work_id, lw.id) AS work_id
+          FROM patch p2
+          LEFT JOIN live_work lw ON lw.id = substring(p2.vndb_id from 6)::bigint
+          LEFT JOIN survivor sv ON sv.start_id = substring(p2.vndb_id from 6)::bigint
+         WHERE p2.vndb_id ~ '^wiki-[0-9]+$') t
+ WHERE p.id = t.patch_id AND t.work_id IS NOT NULL;
 COMMIT;
 
 \echo '=== after, by vndb_id shape'
@@ -63,7 +107,17 @@ SELECT CASE WHEN vndb_id LIKE 'v%' THEN 'v-number'
        count(catalog_work_id) AS mapped
   FROM patch GROUP BY 1 ORDER BY 1;
 
+\echo '=== every id written is a live work (0 = the rule held)'
+SELECT count(*) AS not_live
+  FROM patch p WHERE p.catalog_work_id IS NOT NULL
+   AND p.catalog_work_id NOT IN (SELECT id FROM live_work);
+
+\echo '=== works named by more than one patch (the index is not unique for this reason)'
+SELECT count(*) AS colliding_works FROM (
+  SELECT catalog_work_id FROM patch WHERE catalog_work_id IS NOT NULL
+   GROUP BY 1 HAVING count(*) > 1) x;
+
 \echo '=== favourited patches that still have no work (their favourites cannot migrate)'
-SELECT count(DISTINCT r.galgame_id)
+SELECT count(DISTINCT r.galgame_id) AS patches, count(*) AS favourite_rows
   FROM user_patch_favorite_relation r JOIN patch p ON p.id = r.galgame_id
  WHERE p.catalog_work_id IS NULL;

--- a/apps/web/app/components/patch/folder/PickerModal.vue
+++ b/apps/web/app/components/patch/folder/PickerModal.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+const props = defineProps<{ patchId: number }>()
+const open = defineModel<boolean>({ required: true })
+const emits = defineEmits<{ saved: [payload: { favorited: boolean }] }>()
+
+const api = useApi()
+
+const folders = ref<FolderMembership[]>([])
+const selected = ref<number[]>([])
+const loading = ref(false)
+const saving = ref(false)
+const creating = ref(false)
+const newName = ref('')
+
+const load = async () => {
+  loading.value = true
+  const res = await api.get<{ folders: FolderMembership[] }>(
+    `/patch/${props.patchId}/folder`
+  )
+  loading.value = false
+  if (res.code !== 0) {
+    useKunMessage(res.message || '读取收藏夹失败', 'error')
+    open.value = false
+    return
+  }
+  folders.value = res.data.folders
+  selected.value = res.data.folders.filter((f) => f.contains).map((f) => f.id)
+}
+
+watch(open, (isOpen) => {
+  if (isOpen) load()
+})
+
+const toggle = (id: number) => {
+  const set = new Set(selected.value)
+  if (set.has(id)) {
+    set.delete(id)
+  } else {
+    set.add(id)
+  }
+  selected.value = [...set]
+}
+
+// The default folder is unnamed by design — the backfill wrote empty names and
+// every client derives the label — so it is labelled here rather than shown blank.
+const labelOf = (folder: Folder) =>
+  folder.name.trim() || (folder.is_default ? '默认收藏夹' : '未命名收藏夹')
+
+const createFolder = async () => {
+  const name = newName.value.trim()
+  if (!name) return
+  creating.value = true
+  const res = await api.post<Folder>('/folder', {
+    name,
+    description: '',
+    visibility: 'public'
+  })
+  creating.value = false
+  if (res.code !== 0) {
+    useKunMessage(res.message || '创建收藏夹失败', 'error')
+    return
+  }
+  newName.value = ''
+  folders.value = [...folders.value, { ...res.data, contains: false }]
+  toggle(res.data.id)
+}
+
+const save = async () => {
+  saving.value = true
+  const res = await api.put<{ favorited: boolean }>(
+    `/patch/${props.patchId}/folder`,
+    { folder_ids: selected.value }
+  )
+  saving.value = false
+  if (res.code !== 0) {
+    useKunMessage(res.message || '保存失败', 'error')
+    return
+  }
+  emits('saved', { favorited: selected.value.length > 0 })
+  useKunMessage('已保存', 'success')
+  open.value = false
+}
+</script>
+
+<template>
+  <KunModal v-model="open" inner-class-name="max-w-md" aria-label="加入收藏夹">
+    <div class="space-y-4">
+      <h3 class="text-foreground text-lg font-semibold">加入收藏夹</h3>
+
+      <KunLoading v-if="loading" description="加载中..." />
+
+      <div v-else class="max-h-72 space-y-2 overflow-y-auto">
+        <label
+          v-for="folder in folders"
+          :key="folder.id"
+          class="border-default-200 hover:bg-default-100 flex cursor-pointer items-center gap-3 rounded-xl border px-3 py-2 transition-colors"
+        >
+          <KunCheckBox
+            :model-value="selected.includes(folder.id)"
+            @update:model-value="toggle(folder.id)"
+          />
+          <KunIcon
+            :name="folder.visibility === 'private' ? 'lucide:lock' : 'lucide:globe'"
+            class="text-default-400 size-4 shrink-0"
+          />
+          <div class="min-w-0 flex-1">
+            <p class="text-foreground truncate text-sm">{{ labelOf(folder) }}</p>
+            <p class="text-default-400 text-xs">{{ folder.item_count }} 个游戏</p>
+          </div>
+        </label>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <KunInput
+          v-model="newName"
+          placeholder="新建收藏夹..."
+          class="flex-1"
+          @keyup.enter="createFolder"
+        />
+        <KunButton
+          variant="light"
+          :loading="creating"
+          :disabled="!newName.trim()"
+          @click="createFolder"
+        >
+          新建
+        </KunButton>
+      </div>
+
+      <div class="flex justify-end gap-3">
+        <KunButton variant="light" color="danger" @click="open = false">
+          取消
+        </KunButton>
+        <KunButton color="primary" :loading="saving" @click="save">保存</KunButton>
+      </div>
+    </div>
+  </KunModal>
+</template>

--- a/apps/web/app/components/patch/header/Actions.vue
+++ b/apps/web/app/components/patch/header/Actions.vue
@@ -41,6 +41,18 @@ const onFavoriteChange = async (active: boolean) => {
   }
 }
 
+// The star is "in my default folder"; the picker is the rest of the shelf.
+// Both write to the same catalog folders, so the star has to follow whatever
+// the picker did.
+const pickerOpen = ref(false)
+const openPicker = () => {
+  if (!requireLogin()) return
+  pickerOpen.value = true
+}
+const onFoldersSaved = (payload: { favorited: boolean }) => {
+  favorite.value = payload.favorited
+}
+
 const handleShare = () => {
   const name = getPreferredLanguageText(props.patch.name)
   const link = `${name} - ${window.location.origin}/patch/${props.patch.id}/introduction`
@@ -148,6 +160,16 @@ const onMenuSelect = (item: { key: string }) => {
           {{ favorite ? '已收藏' : '收藏游戏' }}
         </KunReaction>
 
+        <KunButton
+          variant="light"
+          size="md"
+          aria-label="加入收藏夹"
+          @click="openPicker"
+        >
+          <KunIcon name="lucide:folder-plus" class="size-4" />
+          收藏夹
+        </KunButton>
+
         <KunDropdown
           :items="menuItems"
           position="bottom-end"
@@ -223,4 +245,10 @@ const onMenuSelect = (item: { key: string }) => {
       </div>
     </div>
   </KunModal>
+
+    <PatchFolderPickerModal
+      v-model="pickerOpen"
+      :patch-id="props.patch.id"
+      @saved="onFoldersSaved"
+    />
 </template>

--- a/apps/web/app/pages/folder/[id].vue
+++ b/apps/web/app/pages/folder/[id].vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+defineOptions({ name: 'folder-detail' })
+
+const route = useRoute()
+const api = useApi()
+const folderId = computed(() => Number(route.params.id))
+
+interface FolderDetailResponse {
+  folder: Folder | null
+  patches: GalgameCard[]
+}
+
+const { data, pending } = await useAsyncData<FolderDetailResponse>(
+  () => `folder-${folderId.value}`,
+  async () => {
+    const res = await api.get<FolderDetailResponse>(`/folder/${folderId.value}`)
+    return res.code === 0 ? res.data : { folder: null, patches: [] }
+  },
+  { default: () => ({ folder: null, patches: [] }) }
+)
+
+const labelOf = (folder: Folder) =>
+  folder.name.trim() || (folder.is_default ? '默认收藏夹' : '未命名收藏夹')
+
+useHead(() => ({
+  title: data.value?.folder ? `${labelOf(data.value.folder)} - 收藏夹` : '收藏夹'
+}))
+</script>
+
+<template>
+  <div class="mx-auto w-full max-w-7xl space-y-6 p-4">
+    <KunLoading v-if="pending" description="加载中..." />
+
+    <template v-else-if="data?.folder">
+      <div class="space-y-2">
+        <div class="flex items-center gap-2">
+          <KunIcon
+            :name="
+              data.folder.visibility === 'private' ? 'lucide:lock' : 'lucide:folder'
+            "
+            class="text-default-400 size-5 shrink-0"
+          />
+          <h1 class="text-foreground text-xl font-semibold">
+            {{ labelOf(data.folder) }}
+          </h1>
+        </div>
+        <p v-if="data.folder.description" class="text-default-500 text-sm">
+          {{ data.folder.description }}
+        </p>
+        <p class="text-default-400 text-xs">
+          {{ data.folder.item_count }} 个游戏
+          <!-- The folder is shared with the forum, so it can hold games this
+               site has no patch page for. Those are left out rather than
+               rendered as holes, which makes the two numbers differ. -->
+          <template v-if="data.folder.item_count !== data.patches.length">
+            · 本站收录 {{ data.patches.length }} 个
+          </template>
+        </p>
+      </div>
+
+      <GalgameList v-if="data.patches.length" :items="data.patches" />
+      <KunNull v-else description="这个收藏夹还是空的" />
+    </template>
+
+    <KunNull v-else description="收藏夹不存在或未公开" />
+  </div>
+</template>

--- a/apps/web/app/pages/user/[id].vue
+++ b/apps/web/app/pages/user/[id].vue
@@ -38,6 +38,7 @@ const tabs = computed(() => [
   { key: 'galgame', title: 'Galgame', href: `/user/${userId.value}/galgame` },
   { key: 'contribute', title: '贡献', href: `/user/${userId.value}/contribute` },
   { key: 'favorite', title: '收藏', href: `/user/${userId.value}/favorite` },
+  { key: 'folder', title: '收藏夹', href: `/user/${userId.value}/folder` },
   { key: 'comment', title: '评论', href: `/user/${userId.value}/comment` }
 ])
 

--- a/apps/web/app/pages/user/[id]/folder.vue
+++ b/apps/web/app/pages/user/[id]/folder.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+defineOptions({ name: 'user-folder' })
+
+const route = useRoute()
+const api = useApi()
+const userStore = useUserStore()
+const userId = computed(() => Number(route.params.id))
+const isOwner = computed(() => userStore.user.id === userId.value)
+
+const { data, pending, refresh } = await useAsyncData<{ folders: Folder[] }>(
+  () => `user-${userId.value}-folders`,
+  async () => {
+    const res = await api.get<{ folders: Folder[] }>(
+      `/user/${userId.value}/folder`
+    )
+    return res.code === 0 ? res.data : { folders: [] }
+  },
+  { default: () => ({ folders: [] }) }
+)
+
+// The default folder carries an empty name on purpose — every client derives
+// the label, so a name invented at import time would freeze one language into
+// everybody's view of somebody else's shelf.
+const labelOf = (folder: Folder) =>
+  folder.name.trim() || (folder.is_default ? '默认收藏夹' : '未命名收藏夹')
+
+const creating = ref(false)
+const newName = ref('')
+
+const createFolder = async () => {
+  const name = newName.value.trim()
+  if (!name) return
+  creating.value = true
+  const res = await api.post<Folder>('/folder', {
+    name,
+    description: '',
+    visibility: 'public'
+  })
+  creating.value = false
+  if (res.code !== 0) {
+    useKunMessage(res.message || '创建收藏夹失败', 'error')
+    return
+  }
+  newName.value = ''
+  await refresh()
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <div v-if="isOwner" class="flex items-center gap-2">
+      <KunInput
+        v-model="newName"
+        placeholder="新建收藏夹..."
+        class="max-w-xs flex-1"
+        @keyup.enter="createFolder"
+      />
+      <KunButton
+        color="primary"
+        :loading="creating"
+        :disabled="!newName.trim()"
+        @click="createFolder"
+      >
+        新建
+      </KunButton>
+    </div>
+
+    <KunLoading v-if="pending" description="加载中..." />
+
+    <div
+      v-else-if="data?.folders?.length"
+      class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3"
+    >
+      <KunLink
+        v-for="folder in data.folders"
+        :key="folder.id"
+        :to="`/folder/${folder.id}`"
+        class="border-default-200 hover:bg-default-100 block rounded-xl border p-4 transition-colors"
+      >
+        <div class="flex items-start gap-3">
+          <KunIcon
+            :name="folder.visibility === 'private' ? 'lucide:lock' : 'lucide:folder'"
+            class="text-default-400 mt-0.5 size-5 shrink-0"
+          />
+          <div class="min-w-0 flex-1">
+            <p class="text-foreground truncate font-medium">
+              {{ labelOf(folder) }}
+            </p>
+            <p
+              v-if="folder.description"
+              class="text-default-500 mt-1 line-clamp-2 text-xs"
+            >
+              {{ folder.description }}
+            </p>
+            <p class="text-default-400 mt-1 text-xs">
+              {{ folder.item_count }} 个游戏
+            </p>
+          </div>
+        </div>
+      </KunLink>
+    </div>
+
+    <KunNull
+      v-else
+      :description="isOwner ? '你还没有收藏夹' : '该用户没有公开的收藏夹'"
+    />
+  </div>
+</template>

--- a/apps/web/app/shared/types/folder.d.ts
+++ b/apps/web/app/shared/types/folder.d.ts
@@ -1,0 +1,21 @@
+// A folder is a catalog folder (nextmoe-infra /v2/me/folders), shared with the
+// forum: the same shelf, whichever site you file from. This site's API is a
+// thin face over it, see apps/api/internal/patch/service/folders.go.
+//
+// `id` is the CATALOG folder id, not a patch id.
+type FolderVisibility = 'public' | 'private'
+
+interface Folder {
+  id: number
+  name: string
+  description: string
+  visibility: FolderVisibility
+  is_default: boolean
+  item_count: number
+  created: string
+  updated: string
+}
+
+interface FolderMembership extends Folder {
+  contains: boolean
+}

--- a/apps/web/app/shared/utils/pkce.ts
+++ b/apps/web/app/shared/utils/pkce.ts
@@ -111,7 +111,11 @@ const prepareAuthorizeUrl = async (
     // submission. A token minted without it can never gain it by refreshing —
     // the grant is fixed at authorization — so a session from before this line
     // must log in again, which is what house code 40399 tells the user.
-    scope: 'openid profile catalog:edit',
+    // folder:read / folder:write back the 收藏夹 face, which stores favorites
+    // in the catalog rather than in user_patch_favorite_relation. Same fixed
+    // grant as catalog:edit above: a session minted before this line is 403
+    // SCOPE_REQUIRED on every folder call and must log in again.
+    scope: 'openid profile catalog:edit folder:read folder:write',
     state,
     code_challenge: codeChallenge,
     code_challenge_method: 'S256'


### PR DESCRIPTION
This site never had folders — a favourite was one row in `user_patch_favorite_relation` — and the 2026-09-07 backfill moved all **61,796** of them into each person's **default** catalog folder. So the star button keeps meaning exactly what it meant: in or out of the default folder. **Folders are the new part**, and they are the *same* folders the forum shows: a shelf filled there is a shelf here.

`user_patch_favorite_relation` is frozen from this commit as rollback material and read by nothing.

**The migration and the backfill have already been run against production** (2026-09-08), so merging this is a plain deploy.

## `patch.id` is not a catalog work id

Measured on production. The offset between the two id spaces is **not constant**:

| `patch_id − work_id` | rows |
|---|---|
| 185 | 1,108 |
| 0 | 929 |
| 4 | 907 |
| 7 | 595 |
| 177 | 370 |

Both spaces densely cover 1..229256, which makes *"every patch id names some work"* true and **worthless as evidence** — I checked that first and it said 10,921/10,921. The ground truth is the vndb number both sides carry: catalog work **922** and patch **923** are both **v14321**.

Migration **034** adds `patch.catalog_work_id`, and `scripts/backfill-patch-catalog-work-id.sql` fills it from the catalog's **exact** vndb anchor (`entity_type = 5`, `link_kind = 0`), follows `catalog_redirect` to the survivor of a merge, and requires the target to be live — the same three steps `import-favorites` took, so the column agrees with where those 61,796 favourites actually landed. The anchor is unique: 65,078 rows, 65,078 distinct external ids, 0 duplicates.

Resolving per request instead would be an extra catalog call on every star click and, worse, has **no reverse direction**: rendering "my favourites" means turning work ids back into patches, one call per row. Nullable, because 78 of 10,925 patches carry a `pending-<n>` placeholder and have no work at all; their favourites cannot travel, and the refusal is explicit rather than a silent landing on work 0.

## Three defects the production run found

The backfill died on its first real run:

```
ERROR:  duplicate key value violates unique constraint "idx_patch_catalog_work"
DETAIL:  Key (catalog_work_id)=(61311) already exists.
```

**1. The index was UNIQUE**, asserting this site has no two pages for one game. It has **20**. The site dedupes on the vndb_id *string*, so a game arriving once as `wiki-61311` and once as `v65869` gets two rows, and the catalog says those are one work. That is not this site's invariant to hold — the column points into somebody else's id space. The index is now plain, and both rows keep the work id, which is right: a heart on either page is the same favourite.

Only the rendering has to pick one, and `PatchIDsByWorkIDs` collapsed duplicates into a map **with no ORDER BY** — the page it showed was whichever row the planner returned last. It now orders by `published`, `resource_count`, `is_stub`, `id`: the page a reader should land on. The rule had two copies (patch and user repositories); both now call one function in `pkg/utils`.

**2. The backfill did not resolve the way the importer does.** It checked liveness on `wiki-<n>` only and followed no redirect at all — so a v-number anchored to a since-merged work would have been stored as the merged id while the favourite sat on the survivor: the list renders nothing, the star refuses. It also only ever *added* values, so a work merged away after a run kept its stale id. The transaction is now a full re-derivation and the script asserts afterwards that every id it wrote is live. `wiki-N` coverage went 157/177 → **177/177**.

**3. `ErrNoCatalogWork` was defined and mapped nowhere** — it fell through to a 500 *"please try again later"* for a condition no retry can fix, on 80 published patches. It is now a 422 that says the game is not in the catalog yet.

## What could not travel

10,834 of 10,925 patches are mapped, every one to a live work. The 91 that are not hold **509 favourites across 197 people**.

They are not lost. `user_patch_favorite_relation` keeps every row, and `import-favorites` already counts them — `skipped_no_anchor=67` plus `skipped_pending=442` is 509 exactly — so a re-run picks them up the day the catalog gains those works.

Of the 13 v-numbers: **6** are absent from the catalog, **5** have only a *probable* anchor, and **2** have an exact anchor marked dead. The probable ones are the argument against using them: `v1523` and `v8739` both point at work 4082, and `v7635` and `v63090` both point at work 1241 — a guess that lands somebody's favourite on the wrong game is worse than a favourite that waits.

## New

| | |
|---|---|
| `GET /folder` | my folders |
| `POST /folder` | create |
| `GET /folder/:folderId` | one folder and the patches it holds |
| `PATCH /folder/:folderId` | rename / re-describe / change visibility |
| `DELETE /folder/:folderId` | |
| `GET /patch/:id/folder` | the picker: my folders, each flagged `contains` |
| `PUT /patch/:id/folder` | set exactly which of my folders hold this game |
| `GET /user/:id/folder` | somebody's folders — public ones unless it is you |

Web: an "收藏夹" button beside the star opens a picker (tick folders, or type a name to make one); a **收藏夹** tab on the profile; a folder page at `/folder/:id`.

## Cut over

The star button, `is_favorite` on a patch card, and `/user/:id/favorite`.

The favourites list **keeps its SQL** — the empty-patch filter, the content-limit scope, the ordering and the paging are the query this site always ran. Only the id set now arrives over HTTP.

A folder can hold a game this site has no patch page for, because the forum writes to the same folder. Those are dropped rather than rendered as holes, and the folder page says so when the two counts differ.

The default folder is created on demand and deliberately **unnamed**: the backfill wrote empty names and every client derives the label, so a name invented here would freeze one language into somebody else's view.

Local side effects — `patch.favorite_count` and the author's moemoepoints — follow the upstream write rather than preceding it. The number a reader sees on a game page comes from the catalog's `nextmoe/favorites` row, which counts people across every site; the local counter only backs this site's own sorting.

`folder:read` / `folder:write` join the authorize request. A grant is fixed at authorization and a refresh cannot widen it, so sessions from before this line get 403 `SCOPE_REQUIRED`, mapped to the re-login this site already has for `catalog:edit`. The client's `allowed_scopes` is the other half and is already in place upstream.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — 19 packages green.
- `nuxt typecheck` clean.
- **7 client tests plus 3 for the collision, each actually executed** (`-v` confirmed): the two lanes take different credentials — user token for `/v2/me`, application key for the public face, which is the exact shape of the cover-vote outage; `owner_uid` and `contains_work_id` reach the wire; the walk threads cursors to the end and decodes ids; every write addresses the route it claims; a `SCOPE_REQUIRED` refusal survives as a `Problem` carrying the code; an unset field is not sent; the tie-break reaches the generated SQL; and the two real colliding pairs render as 61311 and 61533 rather than whichever the planner returned.
- The backfill ran against production and self-checks: 0 ids written that are not live works.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD
