### PR TITLE
refactor(patch): bid is a Bangumi subject id, so call it that (1/2)

### DIFF
--- a/apps/api/internal/galgame/enricher/enricher.go
+++ b/apps/api/internal/galgame/enricher/enricher.go
@@ -24,7 +24,7 @@ type GalgameCard struct {
 	ID                 int                         `json:"id"`
 	Name               KunLanguage                 `json:"name"`
 	VndbID             string                      `json:"vndb_id"`
-	BID                *int                        `json:"bid"`
+	BangumiID          *int                        `json:"bangumi_id"`
 	Banner             string                      `json:"banner"`
 	View               int                         `json:"view"`
 	Download           int                         `json:"download"`
@@ -407,7 +407,7 @@ func baseCard(p *patchModel.Patch) GalgameCard {
 	return GalgameCard{
 		ID:                 p.ID,
 		VndbID:             p.VndbID,
-		BID:                p.BID,
+		BangumiID:          p.BangumiID,
 		View:               p.View,
 		Download:           p.Download,
 		Type:               p.Type,

--- a/apps/api/internal/patch/model/model.go
+++ b/apps/api/internal/patch/model/model.go
@@ -64,7 +64,7 @@ func (j JSONArray) Value() (driver.Value, error) {
 type Patch struct {
 	ID                 int       `gorm:"primaryKey;autoIncrement" json:"id"`
 	VndbID             string    `gorm:"uniqueIndex;type:varchar(107);not null" json:"vndb_id"`
-	BID                *int      `gorm:"column:bid;uniqueIndex" json:"bid"`
+	BangumiID          *int      `gorm:"column:bangumi_id;uniqueIndex" json:"bangumi_id"`
 	Status             int       `gorm:"default:0" json:"status"`
 	Download           int       `gorm:"default:0" json:"download"`
 	View               int       `gorm:"default:0" json:"view"`

--- a/apps/api/migrations/035_patch_bangumi_id_column.down.sql
+++ b/apps/api/migrations/035_patch_bangumi_id_column.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS patch_bangumi_id_key;
+ALTER TABLE patch DROP COLUMN IF EXISTS bangumi_id;

--- a/apps/api/migrations/035_patch_bangumi_id_column.up.sql
+++ b/apps/api/migrations/035_patch_bangumi_id_column.up.sql
@@ -1,0 +1,33 @@
+-- `bid` never said what it holds. It is a Bangumi subject id, and the code has
+-- always known that without the schema saying so: the detail page builds
+-- https://bangumi.tv/subject/${detail.bid} out of it, and the ratings block maps
+-- source === 'bangumi' onto it. Nothing else in this database is called `bid`,
+-- so the name carried no convention either — it just cost every reader one hop
+-- through a template string to find out.
+--
+-- It came up on 2026-09-08 while looking for a way to map the patch pages the
+-- vndb-only lane cannot see. 6,095 of 10,925 patches carry this id, catalog
+-- holds 32,947 exact bangumi anchors, and the two had never been joined because
+-- the column did not look like an external id. Confirmed by positive control
+-- before renaming: for patches 1..5 the value equals the bangumi anchor of
+-- catalog works 1..5 exactly, five for five.
+--
+-- STEP 1 OF 2, and the split is the whole point. A plain RENAME is not
+-- backwards compatible, and this project deploys by running the migrate
+-- container to completion and only THEN recreating the api container: for the
+-- ten to thirty seconds in between, the OLD binary is live and still asking for
+-- `bid`. GORM builds its column list from the model, so every query touching
+-- the patch table would fail — the detail page and every card list. Adding the
+-- new column instead leaves `bid` in place for that binary to keep reading, so
+-- this step has no error window at all. 036 drops `bid` once nothing runs that
+-- reads it.
+ALTER TABLE patch ADD COLUMN IF NOT EXISTS bangumi_id integer;
+
+UPDATE patch SET bangumi_id = bid WHERE bangumi_id IS NULL AND bid IS NOT NULL;
+
+-- Unique like the index it replaces. This one is unique on this site's own
+-- invariant ("no two patch pages are the same Bangumi subject"), which is a
+-- different claim from idx_patch_catalog_work's — and that one is deliberately
+-- NOT unique. See 034 for why mirroring somebody else's id space must not
+-- assert their dedup quality.
+CREATE UNIQUE INDEX IF NOT EXISTS patch_bangumi_id_key ON patch (bangumi_id);

--- a/apps/api/scripts/backfill-patch-catalog-work-id.sql
+++ b/apps/api/scripts/backfill-patch-catalog-work-id.sql
@@ -96,6 +96,40 @@ UPDATE patch p SET catalog_work_id = t.work_id
           LEFT JOIN survivor sv ON sv.start_id = substring(p2.vndb_id from 6)::bigint
          WHERE p2.vndb_id ~ '^wiki-[0-9]+$') t
  WHERE p.id = t.patch_id AND t.work_id IS NOT NULL;
+
+-- Four rows the rules above cannot reach, decided by hand on 2026-09-08. They
+-- are listed here rather than left in the database because the re-derivation
+-- above wipes the column first: without this block a re-run silently unmaps
+-- them again and 34 favourites go back to being stranded.
+--
+-- catalog identifies only 29% of its live works by a vndb anchor, so a page can
+-- be perfectly well known upstream and invisible to both rules above. Each of
+-- these was resolved from anchors catalog holds under other sources, and each
+-- was checked against the target work's own anchors before being written:
+--
+--   7494  pending-7494 -> 7323   bangumi 550808 AND egs 38246, both exact, plus dlsite RJ01341157
+--   6682  pending-6682 -> 6526   bangumi 83843 exact, plus dlsite VJ003627
+--   1245  v7635        -> 1241   bangumi 63070 exact; the patch's own v7635 is a probable
+--                                anchor on that same work, so the two agree
+--   4107  v8739        -> 4082   bangumi 224744 exact; same corroboration via v8739
+--
+-- Two candidates were REFUSED and must stay refused unless somebody adjudicates
+-- them; they are named so the next reader does not "complete" the list:
+--   7668  v134628 (34 favourites) - its bangumi id names work 2755, whose own
+--         exact vndb anchor is v54849. Two different VNDB entries, and catalog
+--         has never held a v134628 anchor at all. One of the two ids is wrong
+--         and the data does not say which.
+--   6679  its bangumi id names work 6523 while its erogamescape id names work
+--         2656. Two identity-grade anchors, two different works.
+--
+-- The guard is the point: a row is only written when it is still unmapped, so
+-- if a future vndb anchor appears the derived rule wins and this list goes
+-- quiet on its own.
+UPDATE patch SET catalog_work_id = v.work_id
+  FROM (VALUES (7494, 7323), (6682, 6526), (1245, 1241), (4107, 4082)) AS v(patch_id, work_id)
+ WHERE patch.id = v.patch_id
+   AND patch.catalog_work_id IS NULL
+   AND v.work_id IN (SELECT id FROM live_work);
 COMMIT;
 
 \echo '=== after, by vndb_id shape'

--- a/apps/web/app/components/galgame/Ratings.vue
+++ b/apps/web/app/components/galgame/Ratings.vue
@@ -8,12 +8,12 @@ import {
 const props = defineProps<{
   ratings: PatchDetailRating[]
   vndbId?: string
-  bid?: number | null
+  bangumiId?: number | null
 }>()
 
 const refOf = (source: string) => {
   if (source === 'vndb') return props.vndbId ?? ''
-  if (source === 'bangumi') return props.bid ? String(props.bid) : ''
+  if (source === 'bangumi') return props.bangumiId ? String(props.bangumiId) : ''
   return ''
 }
 

--- a/apps/web/app/pages/patch/[id]/introduction.vue
+++ b/apps/web/app/pages/patch/[id]/introduction.vue
@@ -183,17 +183,17 @@ const kungalOrigin = kunMoyuMoe.domain.kungal
             </a>
           </span>
         </div>
-        <div v-if="detail.bid" class="flex items-center gap-2 text-sm">
+        <div v-if="detail.bangumi_id" class="flex items-center gap-2 text-sm">
           <KunIcon name="lucide:tv" class="size-4" />
           <span>
             Bangumi ID:
             <a
-              :href="`https://bangumi.tv/subject/${detail.bid}`"
+              :href="`https://bangumi.tv/subject/${detail.bangumi_id}`"
               target="_blank"
               rel="noopener noreferrer"
               class="text-primary hover:underline"
             >
-              {{ detail.bid }}
+              {{ detail.bangumi_id }}
             </a>
           </span>
         </div>
@@ -203,7 +203,7 @@ const kungalOrigin = kunMoyuMoe.domain.kungal
     <GalgameRatings
       :ratings="detail.ratings ?? []"
       :vndb-id="detail.vndb_id"
-      :bid="detail.bid"
+      :bangumi-id="detail.bangumi_id"
     />
 
     <section v-if="detail.tags?.length" class="space-y-4">

--- a/apps/web/app/shared/types/patch.d.ts
+++ b/apps/web/app/shared/types/patch.d.ts
@@ -24,7 +24,7 @@ interface GalgameCard {
   id: number
   name: KunLanguage
   vndb_id: string
-  bid: number | null
+  bangumi_id: number | null
   banner: string
   // Pinned-cover metadata at the TOP level, which is the shape a flat catalog
   // hit hands over (the /galgame/search/publish picker) as opposed to the


### PR DESCRIPTION
**Step 1 of 2. This step has no error window — it only adds.**

`bid` never said what it holds. It is a **Bangumi subject id**, and the code has always known that without the schema saying so — the detail page builds `https://bangumi.tv/subject/${detail.bid}` out of it, and the ratings block maps `source === 'bangumi'` onto it. Nothing else in this database is called `bid`, so the name carried no local convention either.

It surfaced on 2026-09-08 while looking for a way to map the patch pages the vndb-only lane cannot see: **6,095 of 10,925 patches carry this id** and catalog holds **32,947 exact bangumi anchors**, and the two had never been joined, because the column did not look like an external id.

Positive control before renaming: for patches 1..5 the value equals the bangumi anchor of catalog works 1..5 **exactly, five for five**.

### Why it is split in two

A plain `RENAME` is not backwards compatible. This project runs the migrate container to completion and **then** recreates the api container, so for the ten to thirty seconds in between the **old** binary is live and still asking for `bid`. GORM builds its column list from the model, so every query touching the patch table would fail — the detail page and every card list.

So this step only **adds** `bangumi_id`, copies the values across and indexes it. `bid` stays exactly where it is for the old binary to keep reading. #33 drops it afterwards.

### What is renamed here

GORM field and tag · the enricher's `GalgameCard` field · **the JSON key** · the frontend type · the detail page · the ratings component's prop.

Nothing outside this repository reads the field — checked across the forum and infra checkouts before the JSON key was touched.

### The backfill script grows a short hand-decided list

It re-derives the whole `catalog_work_id` column from scratch on every run, so the four rows mapped by hand on 2026-09-08 from bangumi / erogamescape / dlsite anchors would be silently unmapped again on the next run, taking 34 favourites with them. The two candidates that were **refused** are named in the same comment so the next reader does not "complete" the list:

- **7668** — its bangumi id names work 2755, whose own exact vndb anchor is `v54849` while the patch claims `v134628`.
- **6679** — its bangumi id names work 6523 while its erogamescape id names work 2656.

### Deploy order

1. merge **this** PR → deploy → confirm the release is running
2. then merge #33 → deploy

### Verification

`gofmt` clean, `go build ./...` clean, `go vet ./...` clean, `go test ./...` green across all packages. The frontend rename is grep-verified (`\bbid\b` returns nothing under `apps/web`); CI does not gate `typecheck` and the worktree has no `node_modules`, so it was not run.

Historical records under `docs/api/checks/_audit/` and `docs/proj/next-fiber/` still quote `bid`; those are dated records of checks and designs from the time, left as written.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD
