### PR TITLE
refactor(patch): drop the old bid column (2/2)

### DIFF
--- a/apps/api/migrations/036_drop_patch_bid.down.sql
+++ b/apps/api/migrations/036_drop_patch_bid.down.sql
@@ -1,0 +1,6 @@
+-- Restores the column and its index, then refills it from bangumi_id. The
+-- values come back; the rows that only ever existed after 035 get theirs from
+-- the new column, which is the only place they were ever written.
+ALTER TABLE patch ADD COLUMN IF NOT EXISTS bid integer;
+UPDATE patch SET bid = bangumi_id WHERE bid IS NULL AND bangumi_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS patch_bid_key ON patch (bid);

--- a/apps/api/migrations/036_drop_patch_bid.up.sql
+++ b/apps/api/migrations/036_drop_patch_bid.up.sql
@@ -1,0 +1,15 @@
+-- STEP 2 OF 2. 035 added bangumi_id beside `bid` and moved every reader and
+-- writer onto it; this drops the old column. Deploy this only after the 035
+-- release is actually running — the point of the split is that no live binary
+-- may still be asking for `bid` when it disappears.
+--
+-- The re-copy is not belt-and-braces. Between 035's migrate container finishing
+-- and its api container being recreated, the OLD binary was still live and its
+-- GORM model still wrote `bid` and not `bangumi_id`, so a patch created in that
+-- ten-to-thirty second window carries the old column and an empty new one. It
+-- is a handful of rows at most and usually none, but "usually none" is not a
+-- reason to drop the only copy of somebody's Bangumi link.
+UPDATE patch SET bangumi_id = bid WHERE bangumi_id IS NULL AND bid IS NOT NULL;
+
+DROP INDEX IF EXISTS patch_bid_key;
+ALTER TABLE patch DROP COLUMN IF EXISTS bid;


### PR DESCRIPTION
**Step 2 of 2. Do not deploy this until #32's release is actually running.**

#32 added `bangumi_id` beside `bid` and moved every reader and writer onto it. This drops the old column. The whole point of the split is that no live binary may still be asking for `bid` when it disappears — deploying this while the pre-#32 binary is up would produce exactly the ten-to-thirty second outage the split exists to avoid.

### The re-copy first is not belt-and-braces

Between #32's migrate container finishing and its api container being recreated, the old binary was still live and its GORM model still wrote `bid` and **not** `bangumi_id`. A patch created in that window carries the old column and an empty new one. A handful of rows at most and usually none — but "usually none" is not a reason to drop the only copy of somebody's Bangumi link, so the migration re-copies stragglers before the `DROP`.

### Order

1. #32 merged → deployed → release confirmed running
2. **then** this one

Stacked on `rename/bid-to-bangumi-id`, so merge #32 first and this diff becomes the two migration files alone.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD
