### PR TITLE
feat(folder): draw the shelf like the forum's, and page the folder itself

### DIFF
--- a/apps/api/internal/patch/handler/folders.go
+++ b/apps/api/internal/patch/handler/folders.go
@@ -17,6 +17,8 @@ import (
 const (
 	folderNameMax        = 60
 	folderDescriptionMax = 500
+	// The same page a shelf of galgame cards is drawn at everywhere else.
+	folderPageSize = 24
 )
 
 type folderWriteRequest struct {
@@ -66,7 +68,7 @@ func (h *PatchHandler) MyFolders(c fiber.Ctx) error {
 	if appErr != nil {
 		return response.Error(c, appErr)
 	}
-	folders, err := h.service.MyFolders(c.Context(), token)
+	folders, err := h.service.MyFolders(c.Context(), token, utils.ContentLimitForListBrowse(c))
 	if err != nil {
 		return catalogErr(c, err, "读取收藏夹失败")
 	}
@@ -80,16 +82,17 @@ func (h *PatchHandler) UserFolders(c fiber.Ctx) error {
 	}
 	// Somebody else's shelf shows only what they published. Their own shelf is
 	// MyFolders, which is the only face that knows about private folders.
+	cl := utils.ContentLimitForListBrowse(c)
 	if user := middleware.GetUser(c); user != nil && user.ID == ownerID {
 		if token := middleware.GetAccessToken(c); token != "" {
-			folders, mErr := h.service.MyFolders(c.Context(), token)
+			folders, mErr := h.service.MyFolders(c.Context(), token, cl)
 			if mErr != nil {
 				return catalogErr(c, mErr, "读取收藏夹失败")
 			}
 			return response.OK(c, fiber.Map{"folders": folders})
 		}
 	}
-	folders, pErr := h.service.PublicFolders(c.Context(), ownerID)
+	folders, pErr := h.service.PublicFolders(c.Context(), ownerID, cl)
 	if pErr != nil {
 		return catalogErr(c, pErr, "读取收藏夹失败")
 	}
@@ -172,12 +175,14 @@ func (h *PatchHandler) FolderDetail(c fiber.Ctx) error {
 		return response.Error(c, idErr)
 	}
 	token := middleware.GetAccessToken(c)
+	page := max(fiber.Query(c, "page", 1), 1)
+	limit := min(max(fiber.Query(c, "limit", folderPageSize), 1), folderPageSize)
 	// Try the owner's lane first when there is a token: it is the only one that
 	// answers a private folder, and it 404s just the same when the reader is
 	// not the owner, so nothing leaks by attempting it.
-	folder, patches, err := h.service.FolderPatches(c.Context(), token, folderID, token != "")
+	folder, patches, total, err := h.service.FolderPatches(c.Context(), token, folderID, token != "", page, limit)
 	if err != nil && token != "" {
-		folder, patches, err = h.service.FolderPatches(c.Context(), "", folderID, false)
+		folder, patches, total, err = h.service.FolderPatches(c.Context(), "", folderID, false, page, limit)
 	}
 	if err != nil {
 		return catalogErr(c, err, "读取收藏夹失败")
@@ -186,9 +191,9 @@ func (h *PatchHandler) FolderDetail(c fiber.Ctx) error {
 	// cover and no count, and the shelf drew ten framed placeholders reading
 	// 暂无补丁 that still linked to the right game — the card reads count.resource,
 	// which a bare patch row does not have at all.
-	cl := utils.ContentLimitForListBrowse(c)
-	cards := enricher.EnrichPatchCards(c.Context(), h.galgame, h.users, patches, cl)
-	return response.OK(c, fiber.Map{"folder": folder, "patches": cards})
+	cards := enricher.EnrichPatchCards(c.Context(), h.galgame, h.users, patches,
+		utils.ContentLimitForListBrowse(c))
+	return response.OK(c, fiber.Map{"folder": folder, "patches": cards, "total": total})
 }
 
 func (h *PatchHandler) FoldersForPatch(c fiber.Ctx) error {

--- a/apps/api/internal/patch/service/folders.go
+++ b/apps/api/internal/patch/service/folders.go
@@ -3,9 +3,11 @@ package service
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sort"
 
 	"kun-galgame-patch-api/internal/favorite"
+	galgameClient "kun-galgame-patch-api/internal/galgame/client"
 	"kun-galgame-patch-api/internal/patch/model"
 	"kun-galgame-patch-api/internal/patch/repository"
 	"kun-galgame-patch-api/pkg/catalogv2"
@@ -37,6 +39,8 @@ type FolderView struct {
 	ItemCount   int    `json:"item_count"`
 	Created     string `json:"created"`
 	Updated     string `json:"updated"`
+	// Image hashes, not URLs: this site's clients build the image_service URL.
+	PreviewCovers []string `json:"preview_covers"`
 }
 
 type FolderMembership struct {
@@ -49,6 +53,9 @@ func folderView(f catalogv2.Folder) FolderView {
 		ID: f.ID, Name: f.Name, Description: f.Description, Visibility: f.Visibility,
 		IsDefault: f.IsDefault, ItemCount: f.ItemCount,
 		Created: f.CreatedAt, Updated: f.UpdatedAt,
+		// Empty, not nil: a nil slice marshals to `null` and the card reads
+		// .length off it.
+		PreviewCovers: []string{},
 	}
 }
 
@@ -68,28 +75,109 @@ func (s *PatchService) workIDOf(patchID int) (int64, error) {
 	return s.repo.CatalogWorkID(patchID)
 }
 
-func (s *PatchService) MyFolders(ctx context.Context, token string) ([]FolderView, error) {
+func (s *PatchService) MyFolders(ctx context.Context, token, contentLimit string) ([]FolderView, error) {
 	rows, err := s.galgame.V2().MyFolders(ctx, token)
 	if err != nil {
 		return nil, err
 	}
-	sortFolders(rows)
-	out := make([]FolderView, 0, len(rows))
-	for _, f := range rows {
-		out = append(out, folderView(f))
-	}
+	out := folderViews(rows)
+	s.attachPreviewCovers(ctx, out, token, contentLimit)
 	return out, nil
 }
 
-func (s *PatchService) PublicFolders(ctx context.Context, ownerUID int) ([]FolderView, error) {
+func (s *PatchService) PublicFolders(ctx context.Context, ownerUID int, contentLimit string) ([]FolderView, error) {
 	rows, err := s.galgame.V2().PublicFolders(ctx, int64(ownerUID))
 	if err != nil {
 		return nil, err
 	}
+	out := folderViews(rows)
+	// No token: a stranger's covers come off the public items lane, which
+	// answers public folders only — which is all this list holds.
+	s.attachPreviewCovers(ctx, out, "", contentLimit)
+	return out, nil
+}
+
+func folderViews(rows []catalogv2.Folder) []FolderView {
 	sortFolders(rows)
 	out := make([]FolderView, 0, len(rows))
 	for _, f := range rows {
 		out = append(out, folderView(f))
+	}
+	return out
+}
+
+// previewCoversPerFolder is the mosaic a shelf card draws, and it costs one
+// request per non-empty folder. Measured 2026-09-12: p99 is 3 folders per
+// person and the largest shelf in production has 27, so the loop is not worth
+// paging or parallelising.
+const previewCoversPerFolder = 4
+
+// attachPreviewCovers fills in the covers a folder card draws.
+//
+// A card can come back with fewer covers than the folder has items, or with
+// none: the shelf is shared with kungal and can hold games this site has no
+// page for, and the reader's NSFW gate drops rows here exactly as it does on
+// every other list. Both are the answer, not a failure — which is why a folder
+// that cannot be read at all only loses its covers and still renders.
+func (s *PatchService) attachPreviewCovers(ctx context.Context, views []FolderView, token, contentLimit string) {
+	if s.galgame == nil {
+		return
+	}
+	byFolder := make(map[int64][]int64, len(views))
+	var works []int64
+	for _, v := range views {
+		if v.ItemCount == 0 {
+			continue
+		}
+		items, err := s.galgame.V2().FolderPreviewItems(ctx, token, v.ID, previewCoversPerFolder)
+		if err != nil {
+			slog.Warn("收藏夹封面：读取条目失败", "folder_id", v.ID, "error", err)
+			continue
+		}
+		for _, it := range items {
+			byFolder[v.ID] = append(byFolder[v.ID], it.WorkID)
+			works = append(works, it.WorkID)
+		}
+	}
+	if len(works) == 0 {
+		return
+	}
+	hashes, err := s.bannerHashesByWork(ctx, works, contentLimit)
+	if err != nil {
+		slog.Warn("收藏夹封面：富化失败", "error", err)
+		return
+	}
+	for i := range views {
+		for _, workID := range byFolder[views[i].ID] {
+			if hash := hashes[workID]; hash != "" {
+				views[i].PreviewCovers = append(views[i].PreviewCovers, hash)
+			}
+		}
+	}
+}
+
+func (s *PatchService) bannerHashesByWork(ctx context.Context, workIDs []int64, contentLimit string) (map[int64]string, error) {
+	byWork, err := s.repo.PatchIDsByWorkIDs(workIDs)
+	if err != nil {
+		return nil, err
+	}
+	workOf := make(map[int]int64, len(byWork))
+	ids := make([]int, 0, len(byWork))
+	for workID, patchID := range byWork {
+		workOf[patchID] = workID
+		ids = append(ids, patchID)
+	}
+	out := make(map[int64]string, len(ids))
+	for start := 0; start < len(ids); start += galgameClient.BatchMaxIDs {
+		briefs, bErr := s.galgame.GalgameBatch(ctx, ids[start:min(start+galgameClient.BatchMaxIDs, len(ids))], contentLimit)
+		if bErr != nil {
+			return nil, bErr
+		}
+		for i := range briefs {
+			if h := briefs[i].EffectiveBannerHash; h != "" {
+				out[workOf[briefs[i].ID]] = h
+			}
+		}
 	}
 	return out, nil
 }
@@ -122,7 +210,7 @@ func (s *PatchService) DeleteFolder(ctx context.Context, token string, folderID 
 // this site does not carry are dropped rather than rendered as holes: a person
 // can favourite a game on the forum that has no patch page here, and the
 // folder is shared between the two.
-func (s *PatchService) FolderPatches(ctx context.Context, token string, folderID int64, viewerIsOwner bool) (*FolderView, []model.Patch, error) {
+func (s *PatchService) FolderPatches(ctx context.Context, token string, folderID int64, viewerIsOwner bool, page, limit int) (*FolderView, []model.Patch, int, error) {
 	var (
 		folder *catalogv2.Folder
 		items  []catalogv2.FolderItem
@@ -138,7 +226,7 @@ func (s *PatchService) FolderPatches(ctx context.Context, token string, folderID
 		}
 	}
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
 
 	// Newest added first, which is what a shelf shows. The catalog's own order
@@ -150,7 +238,7 @@ func (s *PatchService) FolderPatches(ctx context.Context, token string, folderID
 	}
 	byWork, mErr := s.repo.PatchIDsByWorkIDs(workIDs)
 	if mErr != nil {
-		return nil, nil, mErr
+		return nil, nil, 0, mErr
 	}
 	ids := make([]int, 0, len(workIDs))
 	for _, w := range workIDs {
@@ -158,12 +246,25 @@ func (s *PatchService) FolderPatches(ctx context.Context, token string, folderID
 			ids = append(ids, pid)
 		}
 	}
-	patches, pErr := s.repo.PatchesByIDsOrdered(ids)
+	// The total is what this site can draw, not folder.ItemCount: a shelf is
+	// shared with kungal and the games it holds that have no page here are
+	// dropped above, so paging on the catalog's count would leave trailing
+	// pages empty.
+	total := len(ids)
+	patches, pErr := s.repo.PatchesByIDsOrdered(pageOfIDs(ids, page, limit))
 	if pErr != nil {
-		return nil, nil, pErr
+		return nil, nil, 0, pErr
 	}
 	v := folderView(*folder)
-	return &v, patches, nil
+	return &v, patches, total, nil
+}
+
+func pageOfIDs(ids []int, page, limit int) []int {
+	start := (max(page, 1) - 1) * limit
+	if start >= len(ids) {
+		return nil
+	}
+	return ids[start:min(start+limit, len(ids))]
 }
 
 // FoldersForPatch is the add-to-folder picker: every folder the person owns,

--- a/apps/api/pkg/catalogv2/folders.go
+++ b/apps/api/pkg/catalogv2/folders.go
@@ -148,6 +148,33 @@ func (c *Client) MyFolderItems(ctx context.Context, accessToken string, folderID
 	return itemsView(rows), err
 }
 
+// FolderPreviewItems is one page of a folder's items and nothing more — what a
+// shelf card needs to draw a few covers. It takes the reader's token for their
+// own folders and the application key for a public one, the same split as the
+// full walk.
+//
+// These are not the newest additions: the catalog orders items by its
+// updated_at sync watermark, and the reading order this site shows is applied
+// after a full walk. A cover mosaic does not care which four it gets; walking
+// every page of every folder to find out would cost a request per hundred
+// items per folder on a page that draws one card each.
+func (c *Client) FolderPreviewItems(ctx context.Context, accessToken string, folderID int64, limit int) ([]FolderItem, error) {
+	q := url.Values{"limit": {strconv.Itoa(min(max(limit, 1), folderPageMax))}}
+	id := strconv.FormatInt(folderID, 10)
+	var page List[folderItemWire]
+	if accessToken != "" {
+		if _, err := c.userDo(ctx, http.MethodGet,
+			"/v2/me/folders/"+id+"/items?"+q.Encode(), accessToken, nil, &page); err != nil {
+			return nil, err
+		}
+		return itemsView(page.Items), nil
+	}
+	if err := c.get(ctx, "/v2/folders/"+id+"/items?"+q.Encode(), &page); err != nil {
+		return nil, err
+	}
+	return itemsView(page.Items), nil
+}
+
 func (c *Client) MyFolder(ctx context.Context, accessToken string, folderID int64) (*Folder, error) {
 	var out folderWire
 	if _, err := c.userDo(ctx, http.MethodGet,

--- a/apps/api/pkg/catalogv2/folders_test.go
+++ b/apps/api/pkg/catalogv2/folders_test.go
@@ -284,3 +284,46 @@ func TestFolderCreateOmitsUnsetFields(t *testing.T) {
 		t.Errorf("name did not travel: %s", seen)
 	}
 }
+
+// A preview is one page and stops there. The full walk exists next to it and
+// follows next_cursor to the end; a shelf card drawing four covers must not,
+// or a person with a 400-item folder pays four requests for a thumbnail.
+func TestFolderPreviewItemsTakeOnePageOnTheRightLane(t *testing.T) {
+	face := &folderFace{pages: map[string][]string{
+		"/v2/me/folders/5/items": {itemListBody("cur_2", 900, 901)},
+		"/v2/folders/6/items":    {itemListBody("cur_2", 902)},
+	}}
+	srv := face.server(t)
+	c := New(srv.URL, "nmk_live_key")
+	ctx := context.Background()
+
+	mine, err := c.FolderPreviewItems(ctx, "user-jwt", 5, 4)
+	if err != nil {
+		t.Fatalf("FolderPreviewItems(own): %v", err)
+	}
+	if len(mine) != 2 {
+		t.Fatalf("want the one page's 2 items, got %d", len(mine))
+	}
+	if _, err = c.FolderPreviewItems(ctx, "", 6, 4); err != nil {
+		t.Fatalf("FolderPreviewItems(public): %v", err)
+	}
+
+	calls := face.calls()
+	if len(calls) != 2 {
+		t.Fatalf("want one request each, got %d: %v", len(calls), calls)
+	}
+	for _, call := range calls {
+		if !strings.Contains(call.Query, "limit=4") {
+			t.Errorf("%s asked %q, want limit=4", call.Path, call.Query)
+		}
+		if strings.Contains(call.Query, "cursor=") {
+			t.Errorf("%s followed the cursor: %q", call.Path, call.Query)
+		}
+	}
+	if calls[0].Auth != "Bearer user-jwt" {
+		t.Errorf("own lane sent %q, want the user token", calls[0].Auth)
+	}
+	if !strings.Contains(calls[1].Auth, "nmk_live_key") {
+		t.Errorf("public lane sent %q, want the application key", calls[1].Auth)
+	}
+}

--- a/apps/web/app/pages/folder/[id].vue
+++ b/apps/web/app/pages/folder/[id].vue
@@ -2,22 +2,42 @@
 defineOptions({ name: 'folder-detail' })
 
 const route = useRoute()
+const router = useRouter()
 const api = useApi()
 const folderId = computed(() => Number(route.params.id))
 
 interface FolderDetailResponse {
   folder: Folder | null
   patches: GalgameCard[]
+  total: number
 }
+
+const page = computed({
+  get: () => Number(route.query.page) || 1,
+  set: (v) => router.replace({ query: { ...route.query, page: String(v) } })
+})
+const limit = 24
+const pageHref = usePageHref()
 
 const { data, pending } = await useAsyncData<FolderDetailResponse>(
   () => `folder-${folderId.value}`,
   async () => {
-    const res = await api.get<FolderDetailResponse>(`/folder/${folderId.value}`)
-    return res.code === 0 ? res.data : { folder: null, patches: [] }
+    const res = await api.get<FolderDetailResponse>(
+      `/folder/${folderId.value}?page=${page.value}&limit=${limit}`
+    )
+    return res.code === 0 ? res.data : { folder: null, patches: [], total: 0 }
   },
-  { default: () => ({ folder: null, patches: [] }) }
+  {
+    default: () => ({ folder: null, patches: [], total: 0 }),
+    watch: [page]
+  }
 )
+
+const totalPages = computed(() => Math.ceil((data.value?.total ?? 0) / limit))
+const onChangePage = (v: number) => {
+  page.value = v
+  if (import.meta.client) window.scrollTo({ top: 0 })
+}
 
 const labelOf = (folder: Folder) =>
   folder.name.trim() || (folder.is_default ? '默认收藏夹' : '未命名收藏夹')
@@ -28,7 +48,7 @@ useHead(() => ({
 </script>
 
 <template>
-  <div class="mx-auto w-full max-w-7xl space-y-6 p-4">
+  <div class="container mx-auto my-4 space-y-6">
     <KunLoading v-if="pending" description="加载中..." />
 
     <template v-else-if="data?.folder">
@@ -54,14 +74,24 @@ useHead(() => ({
                the reader's NSFW gate hides rows here the same way it does on
                every other list. Both are left out rather than rendered as
                holes. -->
-          <template v-if="data.folder.item_count !== data.patches.length">
-            · 本页显示 {{ data.patches.length }} 个
+          <template v-if="data.folder.item_count !== data.total">
+            · 本站收录 {{ data.total }} 个
           </template>
         </p>
       </div>
 
       <GalgameList v-if="data.patches.length" :items="data.patches" />
       <KunNull v-else description="这个收藏夹还是空的" />
+
+      <div v-if="totalPages > 1" class="flex justify-center">
+        <KunPagination
+          :current-page="page"
+          :total-page="totalPages"
+          :is-loading="pending"
+          :page-href="pageHref"
+          @update:current-page="onChangePage"
+        />
+      </div>
     </template>
 
     <KunNull v-else description="收藏夹不存在或未公开" />

--- a/apps/web/app/pages/user/[id]/folder.vue
+++ b/apps/web/app/pages/user/[id]/folder.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { imageServiceUrl } from '~/shared/utils/resolveBannerUrl'
+
 defineOptions({ name: 'user-folder' })
 
 const route = useRoute()
@@ -23,6 +25,17 @@ const { data, pending, refresh } = await useAsyncData<{ folders: Folder[] }>(
 // everybody's view of somebody else's shelf.
 const labelOf = (folder: Folder) =>
   folder.name.trim() || (folder.is_default ? '默认收藏夹' : '未命名收藏夹')
+
+const coversOf = (folder: Folder) =>
+  (folder.preview_covers ?? [])
+    .slice(0, 4)
+    .map((hash) => imageServiceUrl(hash, 'mini'))
+    .filter(Boolean)
+
+const visibilityOf = (folder: Folder) =>
+  folder.visibility === 'private'
+    ? { icon: 'lucide:lock', label: '私密' }
+    : { icon: 'lucide:globe', label: '公开' }
 
 const creating = ref(false)
 const newName = ref('')
@@ -69,35 +82,61 @@ const createFolder = async () => {
 
     <div
       v-else-if="data?.folders?.length"
-      class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3"
+      class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
     >
-      <KunLink
+      <KunCard
         v-for="folder in data.folders"
         :key="folder.id"
-        :to="`/folder/${folder.id}`"
-        class="border-default-200 hover:bg-default-100 block rounded-xl border p-4 transition-colors"
+        :href="`/folder/${folder.id}`"
+        is-hoverable
+        content-class="space-y-3"
       >
-        <div class="flex items-start gap-3">
-          <KunIcon
-            :name="folder.visibility === 'private' ? 'lucide:lock' : 'lucide:folder'"
-            class="text-default-400 mt-0.5 size-5 shrink-0"
+        <div
+          class="bg-default-100 grid aspect-video grid-cols-2 grid-rows-2 gap-0.5 overflow-hidden rounded-lg"
+        >
+          <img
+            v-for="(cover, index) in coversOf(folder)"
+            :key="index"
+            :src="cover"
+            alt=""
+            loading="lazy"
+            :class="
+              cn(
+                'size-full object-cover',
+                coversOf(folder).length === 1 && 'col-span-2 row-span-2'
+              )
+            "
           />
-          <div class="min-w-0 flex-1">
-            <p class="text-foreground truncate font-medium">
-              {{ labelOf(folder) }}
-            </p>
-            <p
-              v-if="folder.description"
-              class="text-default-500 mt-1 line-clamp-2 text-xs"
-            >
-              {{ folder.description }}
-            </p>
-            <p class="text-default-400 mt-1 text-xs">
-              {{ folder.item_count }} 个游戏
-            </p>
+          <div
+            v-if="!coversOf(folder).length"
+            class="text-default-300 col-span-2 row-span-2 flex items-center justify-center"
+          >
+            <KunIcon name="lucide:heart" class="size-10" />
           </div>
         </div>
-      </KunLink>
+
+        <div class="space-y-1">
+          <div class="flex items-center gap-2">
+            <span class="text-foreground truncate font-medium">
+              {{ labelOf(folder) }}
+            </span>
+            <span v-if="folder.is_default" class="text-default-400 shrink-0 text-xs">
+              默认
+            </span>
+          </div>
+          <p
+            v-if="folder.description"
+            class="text-default-500 line-clamp-2 text-xs"
+          >
+            {{ folder.description }}
+          </p>
+          <div class="text-default-500 flex items-center gap-1.5 text-xs">
+            <KunIcon :name="visibilityOf(folder).icon" class="size-3.5" />
+            <span>{{ visibilityOf(folder).label }}</span>
+            <span class="ml-auto">{{ folder.item_count }} 个游戏</span>
+          </div>
+        </div>
+      </KunCard>
     </div>
 
     <KunNull

--- a/apps/web/app/shared/types/folder.d.ts
+++ b/apps/web/app/shared/types/folder.d.ts
@@ -14,6 +14,11 @@ interface Folder {
   item_count: number
   created: string
   updated: string
+  // image_service hashes, not URLs — the card builds the URL. Fewer than
+  // item_count, and sometimes none: the shelf is shared with kungal and can
+  // hold games this site has no page for, and the NSFW gate drops rows here
+  // like it does everywhere else.
+  preview_covers: string[]
 }
 
 interface FolderMembership extends Folder {


### PR DESCRIPTION
用户反馈：「补丁站的收藏夹还是没图」。#36 修的是收藏夹**里面**的卡片（`FolderDetail` 发的是裸 `model.Patch`，没有 `galgame`，因而没有封面）。这个 PR 修的是收藏夹**本身**的样子，以及一个 #36 没碰的问题。

## 收藏夹卡片和论坛一致

原来是一个图标 + 名字 + 数量。现在是 kungal 合集卡的形状：2×2 封面拼图（只有一张时铺满）、名字、默认标记、可见性、数量。两个站看的本来就是同一份收藏夹，卡片没有理由长得不一样。

封面从 catalog 取：每个非空收藏夹要一页 items。生产实测 p99 是每人 3 个收藏夹，全库最大 27 个，所以这个循环没有分页也没有并发。返回的是 image_service hash 而不是 URL，和站内其他地方一致，域名由前端拼。

一张卡可能比它的 `item_count` 少几张封面，也可能一张都没有：收藏夹和 kungal 共用，可以装本站没有页面的游戏；读者的 NSFW 闸门在这里和在任何列表上一样会滤掉行。两者都是答案而不是故障，所以读不到封面的收藏夹只是没有封面，仍然正常渲染。

## 收藏夹详情页分页

`/folder/:id` 之前把整个收藏夹一次画完 —— 生产 p99 是 370 项。现在和 `/galgame`、`收藏` tab 一样每页 24，用同一个 `GalgameList`（也就是同一个 `GalgameCard`）和同一个 `container` 外框。

分页基数是**本站能画出来的数量**，不是 catalog 的 `item_count`：共用收藏夹里那些本站没有页面的游戏在映射时就被丢掉了，按 `item_count` 分页会出现空白的尾页。

## 验证

`go build` / `go vet` / `go test` 全绿，`gofmt` 干净，`nuxt typecheck` 无错。新增一个测试：预览只取一页、不跟 cursor、自己的收藏夹用用户令牌、公开的用应用密钥。

本地没有可用的 catalog（19281 没起），所以封面这条链路是单测 + 类型检查覆盖的，没有跑通端到端。

**无需迁移。**