### PR TITLE
ci: send Dokploy a push body, and fail when it refuses the deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,12 +69,33 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      # Dokploy's compose webhook is a GitHub webhook receiver, not a button.
+      # It reads the branch out of the BODY and only looks there when the
+      # request carries x-github-event, so the bare `curl -X POST` this step
+      # used to send answered `{"message":"Branch Not Match"}` — with status
+      # 301, which `curl -f` does not treat as an error, and a green step.
+      # Every master build since 2026-06-02 pushed images nothing deployed.
+      #
+      # So: forward the push event's own ref and commits, and fail the step on
+      # anything but 200 (301 = branch or watchPaths mismatch, 400 = autoDeploy
+      # off, 404 = wrong token). workflow_dispatch has no commits; watchPaths
+      # is empty on this compose, which matches everything.
       - name: Trigger Dokploy redeploy
         env:
           WEBHOOK: ${{ secrets.DOKPLOY_WEBHOOK_MOYU }}
+          REF: ${{ github.ref }}
+          COMMITS: ${{ toJSON(github.event.commits) }}
         run: |
           if [ -z "$WEBHOOK" ]; then
             echo "DOKPLOY_WEBHOOK_MOYU not set — images pushed to GHCR, skipping redeploy trigger."
             exit 0
           fi
-          curl -fsS -X POST "$WEBHOOK"
+          body=$(jq -nc --arg ref "$REF" --argjson commits "${COMMITS:-null}" \
+            '{ref: $ref, commits: ($commits // [])}')
+          out=$(mktemp)
+          code=$(curl -sS -o "$out" -w '%{http_code}' -X POST "$WEBHOOK" \
+            -H 'Content-Type: application/json' \
+            -H 'X-GitHub-Event: push' \
+            --data "$body")
+          echo "dokploy responded $code: $(cat "$out")"
+          test "$code" = "200"


### PR DESCRIPTION
`deploy` 那一步一直是 `curl -fsS -X POST "$WEBHOOK"`，空 body。

Dokploy 的 compose webhook 不是一个按钮，是 GitHub webhook 接收端。读过它的 handler（`/app/.next/server/pages/api/deploy/compose/[refreshToken].js`）：

```js
u = (headers, body) =>
  headers["x-github-event"] || headers["x-gitea-event"]
    ? body?.ref?.replace("refs/heads/", "")
    : ...
```

分支是从 **body** 里取的，而且只有请求带 `x-github-event` 时才会去看。空 body 拿到 `null`，于是：

```
{"message":"Branch Not Match"}
```

状态码是 **301**，`curl -f` 只对 ≥400 报错，所以这一步一直是绿的。`curl -fsS -X POST` 从 `cc87fae6`（2026-06-02）就是这样，也就是说这三个多月里 master 构建只把镜像推到 GHCR，部署一直是手点的。今天是因为 #36 合了但站上没变化才发现。

## 改成什么

转发 push 事件自己的 `ref` 和 `commits`，带上 `X-GitHub-Event: push`，并且**只接受 200**：

- 301 = 分支或 watchPaths 不匹配
- 400 = autoDeploy 关着
- 404 = token 不对

任何一种现在都是红的构建，日志里带 Dokploy 自己的那句话。

`commits` 用 `toJSON(github.event.commits)` 经 env 传给 `jq`，不拼进脚本，所以 commit message 里有什么都无所谓。`workflow_dispatch` 没有 commits，落到 `[]`；这个 compose 的 `watchPaths` 是空的，空即全匹配。

已核对 Dokploy 侧的配置：`sourceType=github`、`autoDeploy=t`、`branch=master`、`watchPaths={}`，所以唯一没过的就是分支那一关。

## 怎么验证

只能合了才知道 —— secret 只在仓库里，这一步也只在 master push 上跑。合这个 PR 本身就是一次 master push，所以它既是测试，也会顺带把 #36 部署上去。

顺带一提：文件头引的 `docs/deploy/13-registry-ci.md` 在这个仓库里不存在，没动它。